### PR TITLE
refactor(core): decouple repositories from UnitOfWork for domain purity

### DIFF
--- a/TaskForge.NET/TaskForge.Application/Interfaces/Repositories/common/IUnitOfWork.cs
+++ b/TaskForge.NET/TaskForge.Application/Interfaces/Repositories/common/IUnitOfWork.cs
@@ -5,13 +5,6 @@ namespace TaskForge.Application.Interfaces.Repositories.Common
 {
     public interface IUnitOfWork : IDisposable
     {
-        IProjectRepository Projects { get; }
-        ITaskRepository Tasks { get; }
-        IProjectMemberRepository ProjectMembers { get; }
-        IProjectInvitationRepository ProjectInvitations { get; }
-        IUserProfileRepository UserProfiles { get; }
-        ITaskAttachmentRepository TaskAttachments { get; }
-        ITaskAssignmentRepository TaskAssignments { get; }
         Task<IDbContextTransaction> BeginTransactionAsync(IsolationLevel isolationLevel = IsolationLevel.ReadCommitted);
 
         Task<int> SaveChangesAsync();

--- a/TaskForge.NET/TaskForge.Application/Services/ProjectInvitationService.cs
+++ b/TaskForge.NET/TaskForge.Application/Services/ProjectInvitationService.cs
@@ -2,6 +2,7 @@
 using Microsoft.EntityFrameworkCore;
 using TaskForge.Application.Common.Model;
 using TaskForge.Application.DTOs;
+using TaskForge.Application.Interfaces.Repositories;
 using TaskForge.Application.Interfaces.Repositories.Common;
 using TaskForge.Application.Interfaces.Services;
 using TaskForge.Domain.Entities;
@@ -9,133 +10,143 @@ using TaskForge.Domain.Enums;
 
 namespace TaskForge.Application.Services
 {
-    public class ProjectInvitationService : IProjectInvitationService
-    {
-        private readonly IUnitOfWork _unitOfWork;
-        private readonly UserManager<IdentityUser> _userManager;
+	public class ProjectInvitationService : IProjectInvitationService
+	{
+		private readonly IProjectInvitationRepository _projectInvitationRepo;
+		private readonly IProjectMemberRepository _projectMemberRepo;
+		private readonly IUserProfileRepository _userProfileRepo;
+		private readonly IUnitOfWork _unitOfWork;
+		private readonly UserManager<IdentityUser> _userManager;
 
-        public ProjectInvitationService(IUnitOfWork unitOfWork, UserManager<IdentityUser> userManager)
-        {
-            _unitOfWork = unitOfWork;
-            _userManager = userManager;
-        }
+		public ProjectInvitationService(
+			IProjectInvitationRepository projectInvitationRepo,
+			IProjectMemberRepository projectMemberRepo,
+			IUserProfileRepository userProfileRepo,
+			IUnitOfWork unitOfWork,
+			UserManager<IdentityUser> userManager)
+		{
+			_projectInvitationRepo = projectInvitationRepo;
+			_projectMemberRepo = projectMemberRepo;
+			_userProfileRepo = userProfileRepo;
+			_unitOfWork = unitOfWork;
+			_userManager = userManager;
+		}
 
-        public async Task<ProjectInvitation?> GetByIdAsync(int invitationId)
-        {
-            return await _unitOfWork.ProjectInvitations.GetByIdAsync(invitationId);
-        }
+		public async Task<ProjectInvitation?> GetByIdAsync(int invitationId)
+		{
+			return await _projectInvitationRepo.GetByIdAsync(invitationId);
+		}
 
-        public async Task<PaginatedList<ProjectInvitation>> GetInvitationListAsync(int projectId, int pageIndex, int pageSize)
-        {
-            var (projectInvitationList, totalCount) = await _unitOfWork.ProjectInvitations.GetPaginatedListAsync(
-                predicate: pi => pi.ProjectId == projectId,
-                includes: query => query
-                    .Include(pi => pi.InvitedUserProfile) // Include UserProfile
-                        .ThenInclude(pi => pi.User), // Include User inside UserProfile
-                skip: (pageIndex - 1) * pageSize,
-                take: pageSize
-               );
+		public async Task<PaginatedList<ProjectInvitation>> GetInvitationListAsync(int projectId, int pageIndex, int pageSize)
+		{
+			var (projectInvitationList, totalCount) = await _projectInvitationRepo.GetPaginatedListAsync(
+				predicate: pi => pi.ProjectId == projectId,
+				includes: query => query
+					.Include(pi => pi.InvitedUserProfile)
+						.ThenInclude(pi => pi.User),
+				skip: (pageIndex - 1) * pageSize,
+				take: pageSize
+			);
 
-            return new PaginatedList<ProjectInvitation>(projectInvitationList, totalCount, pageIndex, pageSize);
-        }
+			return new PaginatedList<ProjectInvitation>(projectInvitationList, totalCount, pageIndex, pageSize);
+		}
 
-        public async Task<ServiceResult> AddAsync(int projectId, string invitedUserEmail, ProjectRole assignedRole)
-        {
-            // Find the user by email
-            var user = await _userManager.FindByEmailAsync(invitedUserEmail);
-            if (user == null)
-            {
-                return ServiceResult.FailureResult("User not found.");
-            }
+		public async Task<ServiceResult> AddAsync(int projectId, string invitedUserEmail, ProjectRole assignedRole)
+		{
+			var user = await _userManager.FindByEmailAsync(invitedUserEmail);
+			if (user == null)
+			{
+				return ServiceResult.FailureResult("User not found.");
+			}
 
-            // Find the UserProfile for this user
-            var userProfile = await _unitOfWork.UserProfiles
-                .FindByExpressionAsync(up => up.UserId == user.Id);
+			var userProfile = await _userProfileRepo.FindByExpressionAsync(up => up.UserId == user.Id);
+			var userProfileId = userProfile.FirstOrDefault()?.Id;
 
-            var userProfileId = userProfile.FirstOrDefault()?.Id;
-            if (!userProfileId.HasValue || userProfileId.Value == 0)
-            {
-                return ServiceResult.FailureResult("User profile not found.");
-            }
+			if (!userProfileId.HasValue || userProfileId.Value == 0)
+			{
+				return ServiceResult.FailureResult("User profile not found.");
+			}
 
-            // Check if the user is already a member of the project
-            var member = await _unitOfWork.ProjectMembers.FindByExpressionAsync(pm => pm.UserProfile.UserId == user.Id && pm.ProjectId == projectId);
-            if (member != null && member.Any())
-            {
-                return ServiceResult.FailureResult("User is already a member of this project.");
-            }
+			var member = await _projectMemberRepo.FindByExpressionAsync(pm =>
+				pm.UserProfile.UserId == user.Id && pm.ProjectId == projectId);
+			if (member.Any())
+			{
+				return ServiceResult.FailureResult("User is already a member of this project.");
+			}
 
-            // Check if an invitation already exists
-            var existingInvitation = await _unitOfWork.ProjectInvitations.FindByExpressionAsync(i => i.InvitedUserProfileId == userProfileId.Value
-                                            && i.ProjectId == projectId && i.Status == InvitationStatus.Pending);
-            if (existingInvitation.Any())
-            {
-                return ServiceResult.FailureResult("An invitation has already been sent to this user.");
-            }
+			var existingInvitation = await _projectInvitationRepo.FindByExpressionAsync(i =>
+				i.InvitedUserProfileId == userProfileId.Value &&
+				i.ProjectId == projectId &&
+				i.Status == InvitationStatus.Pending);
 
-            // Create a new invitation
-            var invitation = new ProjectInvitation
-            {
-                ProjectId = projectId,
-                InvitedUserProfileId = userProfileId.Value,
-                Status = InvitationStatus.Pending,
-                AssignedRole = assignedRole,
-                InvitationSentDate = DateTime.UtcNow,
-            };
+			if (existingInvitation.Any())
+			{
+				return ServiceResult.FailureResult("An invitation has already been sent to this user.");
+			}
 
-            // Save to database
-            await _unitOfWork.ProjectInvitations.AddAsync(invitation);
-            await _unitOfWork.SaveChangesAsync();
-            return ServiceResult.SuccessResult("Invitation sent successfully.");
-        }
+			var invitation = new ProjectInvitation
+			{
+				ProjectId = projectId,
+				InvitedUserProfileId = userProfileId.Value,
+				Status = InvitationStatus.Pending,
+				AssignedRole = assignedRole,
+				InvitationSentDate = DateTime.UtcNow,
+			};
 
+			await _projectInvitationRepo.AddAsync(invitation);
+			await _unitOfWork.SaveChangesAsync();
+			return ServiceResult.SuccessResult("Invitation sent successfully.");
+		}
 
-        public async Task UpdateInvitationStatusAsync(int id, InvitationStatus status)
-        {
-            var invitation = await GetByIdAsync(id);
-            if (invitation == null)
-            {
-                return;
-            }
+		public async Task UpdateInvitationStatusAsync(int id, InvitationStatus status)
+		{
+			var invitation = await GetByIdAsync(id);
+			if (invitation == null)
+			{
+				return;
+			}
 
-            invitation.Status = status;
+			invitation.Status = status;
 
-            if (status == InvitationStatus.Accepted)
-            {
-                invitation.AcceptedDate = DateTime.UtcNow;
-                invitation.DeclinedDate = null;
+			if (status == InvitationStatus.Accepted)
+			{
+				invitation.AcceptedDate = DateTime.UtcNow;
+				invitation.DeclinedDate = null;
 
-                // Create a ProjectMember entry for the user
-                var projectMember = new ProjectMember
-                {
-                    ProjectId = invitation.ProjectId,
-                    UserProfileId = invitation.InvitedUserProfileId, // Assign the invited user
-                    Role = invitation.AssignedRole, // Assign the role from invitation
-                };
+				var projectMember = new ProjectMember
+				{
+					ProjectId = invitation.ProjectId,
+					UserProfileId = invitation.InvitedUserProfileId,
+					Role = invitation.AssignedRole,
+				};
 
-                await _unitOfWork.ProjectMembers.AddAsync(projectMember);
-            }
-            else if (status == InvitationStatus.Declined)
-            {
-                invitation.DeclinedDate = DateTime.UtcNow;
-                invitation.AcceptedDate = null;
-            }
+				await _projectMemberRepo.AddAsync(projectMember);
+			}
+			else if (status == InvitationStatus.Declined)
+			{
+				invitation.DeclinedDate = DateTime.UtcNow;
+				invitation.AcceptedDate = null;
+			}
 
-            await _unitOfWork.ProjectInvitations.UpdateAsync(invitation);
-            await _unitOfWork.SaveChangesAsync();
-        }
-        public async Task<PaginatedList<ProjectInvitation>> GetInvitationsForUserAsync(int? userProfileId, int pageIndex, int pageSize)
-        {
-            if (!userProfileId.HasValue) return new PaginatedList<ProjectInvitation>(new List<ProjectInvitation>(), 0, pageIndex, pageSize);
+			await _projectInvitationRepo.UpdateAsync(invitation);
+			await _unitOfWork.SaveChangesAsync();
+		}
 
-            var (projectInvitaionList, totalCount) = await _unitOfWork.ProjectInvitations.GetPaginatedListAsync(predicate: pi => pi.InvitedUserProfileId == userProfileId,
-                 orderBy: null,
-                 includes: query => query.Include(pi => pi.Project),
-                 skip: (pageIndex - 1) * pageSize,
-                 take: pageSize
-             );
+		public async Task<PaginatedList<ProjectInvitation>> GetInvitationsForUserAsync(int? userProfileId, int pageIndex, int pageSize)
+		{
+			if (!userProfileId.HasValue)
+			{
+				return new PaginatedList<ProjectInvitation>(new List<ProjectInvitation>(), 0, pageIndex, pageSize);
+			}
 
-            return new PaginatedList<ProjectInvitation>(projectInvitaionList, totalCount, pageIndex, pageSize);
-        }
-    }
+			var (projectInvitationList, totalCount) = await _projectInvitationRepo.GetPaginatedListAsync(
+				predicate: pi => pi.InvitedUserProfileId == userProfileId,
+				includes: query => query.Include(pi => pi.Project),
+				skip: (pageIndex - 1) * pageSize,
+				take: pageSize
+			);
+
+			return new PaginatedList<ProjectInvitation>(projectInvitationList, totalCount, pageIndex, pageSize);
+		}
+	}
 }

--- a/TaskForge.NET/TaskForge.Application/Services/ProjectMemberService.cs
+++ b/TaskForge.NET/TaskForge.Application/Services/ProjectMemberService.cs
@@ -1,81 +1,84 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using TaskForge.Application.DTOs;
+using TaskForge.Application.Interfaces.Repositories;
 using TaskForge.Application.Interfaces.Repositories.Common;
 using TaskForge.Application.Interfaces.Services;
 using TaskForge.Domain.Entities;
 
 namespace TaskForge.Application.Services
 {
-    public class ProjectMemberService : IProjectMemberService
-    {
-        private readonly IUnitOfWork _unitOfWork;
-        public ProjectMemberService(IUnitOfWork unitOfWork)
-        {
-            _unitOfWork = unitOfWork;
-        }
+	public class ProjectMemberService : IProjectMemberService
+	{
+		private readonly IProjectMemberRepository _projectMemberRepository;
+		private readonly IUnitOfWork _unitOfWork;
 
-        public async Task<ProjectMember?> GetByIdAsync(int memberId)
-        {
-            return await _unitOfWork.ProjectMembers.GetByIdAsync(memberId);
-        }
+		public ProjectMemberService(IProjectMemberRepository projectMemberRepository, IUnitOfWork unitOfWork)
+		{
+			_projectMemberRepository = projectMemberRepository;
+			_unitOfWork = unitOfWork;
+		}
 
-        public async Task<ProjectMemberDto?> GetUserProjectRoleAsync(string userId, int projectId)
-        {
-            var projectMember = await _unitOfWork.ProjectMembers.FindByExpressionAsync(
-                pm => pm.UserProfile.UserId == userId && pm.ProjectId == projectId,
-                includes: query => query
-                    .Include(pm => pm.UserProfile)
-                        .ThenInclude(pm => pm.User)
-                );
+		public async Task<ProjectMember?> GetByIdAsync(int memberId)
+		{
+			return await _projectMemberRepository.GetByIdAsync(memberId);
+		}
 
-            var member = projectMember.FirstOrDefault();
-            if (member == null)
-                return null;
+		public async Task<ProjectMemberDto?> GetUserProjectRoleAsync(string userId, int projectId)
+		{
+			var projectMember = await _projectMemberRepository.FindByExpressionAsync(
+				pm => pm.UserProfile.UserId == userId && pm.ProjectId == projectId,
+				includes: query => query
+					.Include(pm => pm.UserProfile)
+						.ThenInclude(pm => pm.User)
+				);
 
-            return new ProjectMemberDto
-            {
-                Id = member.Id,
-                Name = member.UserProfile.FullName ?? "Unknown User",
-                Email = member.UserProfile.User?.UserName ?? "No Email",
-                Role = member.Role
-            };
-        }
+			var member = projectMember.FirstOrDefault();
+			if (member == null)
+				return null;
 
-        public async Task<List<ProjectMemberDto>> GetProjectMembersAsync(int projectId)
-        {
-            var projectMembers = await _unitOfWork.ProjectMembers.FindByExpressionAsync(
-                predicate: pm => pm.ProjectId == projectId,
-                includes: query => query
-                    .Include(pm => pm.UserProfile)
-                        .ThenInclude(pm => pm.User),
-                orderBy: query => query.OrderBy(pm => pm.Role)
-                );
+			return new ProjectMemberDto
+			{
+				Id = member.Id,
+				Name = member.UserProfile.FullName ?? "Unknown User",
+				Email = member.UserProfile.User?.UserName ?? "No Email",
+				Role = member.Role
+			};
+		}
 
-            return projectMembers.Select(pm => new ProjectMemberDto
-            {
-                Id = pm.Id,
-                ProjectId = pm.ProjectId,
-                UserProfileId = pm.UserProfileId,
-                Name = pm.UserProfile.FullName ?? "Unknown User",
-                Email = pm.UserProfile.User?.UserName ?? "No Email",
-                Role = pm.Role
-            }).ToList();
-        }
+		public async Task<List<ProjectMemberDto>> GetProjectMembersAsync(int projectId)
+		{
+			var projectMembers = await _projectMemberRepository.FindByExpressionAsync(
+				predicate: pm => pm.ProjectId == projectId,
+				includes: query => query
+					.Include(pm => pm.UserProfile)
+						.ThenInclude(pm => pm.User),
+				orderBy: query => query.OrderBy(pm => pm.Role)
+			);
 
-        public async Task RemoveAsync(int memberId)
-        {
-            await _unitOfWork.ProjectMembers.DeleteByIdAsync(memberId);
-            await _unitOfWork.SaveChangesAsync();
-        }
+			return projectMembers.Select(pm => new ProjectMemberDto
+			{
+				Id = pm.Id,
+				ProjectId = pm.ProjectId,
+				UserProfileId = pm.UserProfileId,
+				Name = pm.UserProfile.FullName ?? "Unknown User",
+				Email = pm.UserProfile.User?.UserName ?? "No Email",
+				Role = pm.Role
+			}).ToList();
+		}
 
-        public async Task<int> GetUserProjectCountAsync(int? userProfileId)
-        {
-            var projectMembers = await _unitOfWork.ProjectMembers.FindByExpressionAsync(
-                predicate: pm => pm.UserProfileId == userProfileId
-            );
+		public async Task RemoveAsync(int memberId)
+		{
+			await _projectMemberRepository.DeleteByIdAsync(memberId);
+			await _unitOfWork.SaveChangesAsync();
+		}
 
-            return projectMembers.Select(pm => pm.ProjectId).Distinct().Count();
-        }
+		public async Task<int> GetUserProjectCountAsync(int? userProfileId)
+		{
+			var projectMembers = await _projectMemberRepository.FindByExpressionAsync(
+				predicate: pm => pm.UserProfileId == userProfileId
+			);
 
-    }
+			return projectMembers.Select(pm => pm.ProjectId).Distinct().Count();
+		}
+	}
 }

--- a/TaskForge.NET/TaskForge.Application/Services/ProjectService.cs
+++ b/TaskForge.NET/TaskForge.Application/Services/ProjectService.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore;
 using TaskForge.Application.Common.Model;
 using TaskForge.Application.DTOs;
+using TaskForge.Application.Interfaces.Repositories;
 using TaskForge.Application.Interfaces.Repositories.Common;
 using TaskForge.Application.Interfaces.Services;
 using TaskForge.Domain.Entities;
@@ -13,11 +14,23 @@ namespace TaskForge.Application.Services
     public class ProjectService : IProjectService
     {
         private readonly IUnitOfWork _unitOfWork;
+        private readonly IProjectRepository _projectRepository;
+        private readonly IProjectMemberRepository _projectMemberRepository;
+        private readonly IUserProfileRepository _userProfileRepository;
         private readonly IUserProfileService _userProfileService;
 
-        public ProjectService(IUnitOfWork unitOfWork, IUserProfileService userProfileService)
+        public ProjectService(
+	        IUnitOfWork unitOfWork,
+            IProjectRepository projectRepository,
+            IProjectMemberRepository projectMemberRepository,
+            IUserProfileRepository userProfileRepository,
+	        IUserProfileService userProfileService
+	        )
         {
             _unitOfWork = unitOfWork;
+            _projectRepository = projectRepository;
+            _projectMemberRepository = projectMemberRepository;
+            _userProfileRepository = userProfileRepository;
             _userProfileService = userProfileService;
         }
 
@@ -42,13 +55,13 @@ namespace TaskForge.Application.Services
 
                 if (dto.EndDate != null) project.SetEndDate(dto.EndDate);
 
-                await _unitOfWork.Projects.AddAsync(project);
+                await _projectRepository.AddAsync(project);
                 await _unitOfWork.SaveChangesAsync(); // Ensure Project.Id is generated
 
                 var projectId = project.Id;
 
                 // 2. Get the UserProfileId for CreatedBy
-                var userProfileId = (await _unitOfWork.UserProfiles.FindByExpressionAsync(up => up.UserId == dto.CreatedBy))
+                var userProfileId = (await _userProfileRepository.FindByExpressionAsync(up => up.UserId == dto.CreatedBy))
                                    .Select(up => up.Id)
                                    .FirstOrDefault();
 
@@ -64,7 +77,7 @@ namespace TaskForge.Application.Services
                     Role = ProjectRole.Admin
                 };
 
-                await _unitOfWork.ProjectMembers.AddAsync(projectMember);
+                await _projectMemberRepository.AddAsync(projectMember);
                 await _unitOfWork.SaveChangesAsync();
 
                 // 4. Commit transaction
@@ -95,7 +108,7 @@ namespace TaskForge.Application.Services
 
             if (dto.EndDate != null) project.SetEndDate(dto.EndDate);
 
-            await _unitOfWork.Projects.UpdateAsync(project);
+            await _projectRepository.UpdateAsync(project);
             await _unitOfWork.SaveChangesAsync();
         }
 
@@ -114,7 +127,7 @@ namespace TaskForge.Application.Services
 
         public async Task<Project?> GetProjectByIdAsync(int projectId)
         {
-            return (await _unitOfWork.Projects.FindByExpressionAsync(
+            return (await _projectRepository.FindByExpressionAsync(
                     predicate: p => p.Id == projectId,
                     includes: query => query
                         .Include(p => p.Members)
@@ -137,7 +150,7 @@ namespace TaskForge.Application.Services
             var predicate = BuildPredicate(filter, userProfileId);
             var orderBy = BuildOrderBy(filter);
 
-            var (filteredProjectList, totalCount) = await _unitOfWork.ProjectMembers.GetPaginatedListAsync(
+            var (filteredProjectList, totalCount) = await _projectMemberRepository.GetPaginatedListAsync(
                 predicate: predicate,
                 orderBy: orderBy,
                 includes: query => query.Include(pm => pm.Project),

--- a/TaskForge.NET/TaskForge.Application/Services/UserProfileService.cs
+++ b/TaskForge.NET/TaskForge.Application/Services/UserProfileService.cs
@@ -1,4 +1,5 @@
-﻿using TaskForge.Application.Interfaces.Repositories.Common;
+﻿using TaskForge.Application.Interfaces.Repositories;
+using TaskForge.Application.Interfaces.Repositories.Common;
 using TaskForge.Application.Interfaces.Services;
 using TaskForge.Domain.Entities;
 
@@ -7,9 +8,11 @@ namespace TaskForge.Application.Services
     public class UserProfileService : IUserProfileService
     {
         private readonly IUnitOfWork _unitOfWork;
-        public UserProfileService(IUnitOfWork unitOfWork)
+        private readonly IUserProfileRepository _userProfileRepository;
+        public UserProfileService(IUnitOfWork unitOfWork, IUserProfileRepository userProfileRepository)
         {
             _unitOfWork = unitOfWork;
+            _userProfileRepository = userProfileRepository;
         }
 
         public async Task CreateUserProfileAsync(string userId, string fullName)
@@ -19,13 +22,13 @@ namespace TaskForge.Application.Services
                 UserId = userId,
                 FullName = fullName
             };
-            await _unitOfWork.UserProfiles.AddAsync(userProfile);
+            await _userProfileRepository.AddAsync(userProfile);
             await _unitOfWork.SaveChangesAsync();
         }
 
 		public async Task<int?> GetByUserIdAsync(string userId)
 		{
-			var userProfiles = await _unitOfWork.UserProfiles
+			var userProfiles = await _userProfileRepository
 				.FindByExpressionAsync(up => up.UserId == userId);
 
 			var userProfile = userProfiles.FirstOrDefault();

--- a/TaskForge.NET/TaskForge.Infrastructure/Repositories/common/UnitOfWork.cs
+++ b/TaskForge.NET/TaskForge.Infrastructure/Repositories/common/UnitOfWork.cs
@@ -1,9 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
 using System.Data;
-using TaskForge.Application.Interfaces.Repositories;
 using TaskForge.Application.Interfaces.Repositories.Common;
-using TaskForge.Application.Interfaces.Services;
 using TaskForge.Infrastructure.Data;
 
 namespace TaskForge.Infrastructure.Repositories.Common
@@ -11,27 +9,11 @@ namespace TaskForge.Infrastructure.Repositories.Common
     public class UnitOfWork : IUnitOfWork
     {
         private readonly ApplicationDbContext _context;
-        private bool _disposed = false;
+        private bool _disposed;
 
-        public IProjectRepository Projects { get; }
-        public ITaskRepository Tasks { get; }
-        public IProjectMemberRepository ProjectMembers { get; }
-        public IProjectInvitationRepository ProjectInvitations { get; }
-        public IUserProfileRepository UserProfiles { get; }
-        public ITaskAttachmentRepository TaskAttachments { get; }
-        public ITaskAssignmentRepository TaskAssignments { get; }
-
-        public UnitOfWork(ApplicationDbContext context, IUserContextService userContextService)
+        public UnitOfWork(ApplicationDbContext context)
         {
             _context = context;
-
-            Projects = new ProjectRepository(context, userContextService);
-            Tasks = new TaskRepository(context, userContextService);
-            ProjectMembers = new ProjectMemberRepository(context, userContextService);
-            ProjectInvitations = new ProjectInvitationRepository(context, userContextService);
-            UserProfiles = new UserProfileRepository(context, userContextService);
-            TaskAttachments = new TaskAttachmentRepository(context, userContextService);
-            TaskAssignments = new TaskAssignmentRepository(context, userContextService);
         }
 
         public async Task<int> SaveChangesAsync()
@@ -46,16 +28,14 @@ namespace TaskForge.Infrastructure.Repositories.Common
 
         protected virtual void Dispose(bool disposing)
         {
-            if (!_disposed)
-            {
-                if (disposing)
-                {
-                    // Dispose managed resources
-                    _context.Dispose();
-                }
-                // Free unmanaged resources (if any)
-                _disposed = true;
-            }
+	        if (_disposed) return;
+	        if (disposing)
+	        {
+		        // Dispose managed resources
+		        _context.Dispose();
+	        }
+	        // Free unmanaged resources (if any)
+	        _disposed = true;
         }
 
         public void Dispose()

--- a/TaskForge.NET/TaskForge.Tests/Application/Services/ProjectInvitationServiceTests.cs
+++ b/TaskForge.NET/TaskForge.Tests/Application/Services/ProjectInvitationServiceTests.cs
@@ -18,7 +18,6 @@ namespace TaskForge.Tests.Application.Services
 		private readonly Mock<IUserProfileRepository> _userProfileRepositoryMock;
 		private readonly Mock<IUnitOfWork> _unitOfWorkMock;
 		private readonly Mock<UserManager<IdentityUser>> _userManagerMock;
-
 		private readonly ProjectInvitationService _projectInvitationService;
 
 		public ProjectInvitationServiceTests()
@@ -545,6 +544,8 @@ namespace TaskForge.Tests.Application.Services
 
 			_projectInvitationRepositoryMock.Setup(u => u.GetByIdAsync(invitationId))
 				.ReturnsAsync(invitation);
+			_projectMemberRepositoryMock.Setup(r => r.AddAsync(It.IsAny<ProjectMember>()))
+				.Returns(Task.CompletedTask);
 
 			// Act
 			await _projectInvitationService.UpdateInvitationStatusAsync(invitationId, InvitationStatus.Accepted);
@@ -581,6 +582,8 @@ namespace TaskForge.Tests.Application.Services
 
 			_projectInvitationRepositoryMock.Setup(u => u.GetByIdAsync(invitationId))
 				.ReturnsAsync(invitation);
+			_projectInvitationRepositoryMock.Setup(r => r.UpdateAsync(invitation))
+				.Returns(Task.CompletedTask);
 
 			// Act
 			await _projectInvitationService.UpdateInvitationStatusAsync(invitationId, InvitationStatus.Declined);

--- a/TaskForge.NET/TaskForge.Tests/Application/Services/ProjectInvitationServiceTests.cs
+++ b/TaskForge.NET/TaskForge.Tests/Application/Services/ProjectInvitationServiceTests.cs
@@ -11,738 +11,733 @@ using Xunit;
 
 namespace TaskForge.Tests.Application.Services
 {
-    public class ProjectInvitationServiceTests
-    {
-        private readonly Mock<IUnitOfWork> _unitOfWorkMock;
-        private readonly Mock<IUserStore<IdentityUser>> _userStoreMock;
-        private readonly Mock<UserManager<IdentityUser>> _userManagerMock;
-        private readonly ProjectInvitationService _projectInvitationService;
+	public class ProjectInvitationServiceTests
+	{
+		private readonly Mock<IProjectInvitationRepository> _projectInvitationRepositoryMock;
+		private readonly Mock<IProjectMemberRepository> _projectMemberRepositoryMock;
+		private readonly Mock<IUserProfileRepository> _userProfileRepositoryMock;
+		private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+		private readonly Mock<UserManager<IdentityUser>> _userManagerMock;
 
-        public ProjectInvitationServiceTests()
-        {
-            _unitOfWorkMock = new Mock<IUnitOfWork>();
-            _userStoreMock = new Mock<IUserStore<IdentityUser>>();
+		private readonly ProjectInvitationService _projectInvitationService;
 
-#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
-            // Create a minimal UserManager
-            _userManagerMock = new Mock<UserManager<IdentityUser>>(
-                _userStoreMock.Object,
-                null, null, null, null, null, null, null,
-                new Mock<ILogger<UserManager<IdentityUser>>>().Object
-            );
+		public ProjectInvitationServiceTests()
+		{
+			_projectInvitationRepositoryMock = new Mock<IProjectInvitationRepository>();
+			_projectMemberRepositoryMock = new Mock<IProjectMemberRepository>();
+			_userProfileRepositoryMock = new Mock<IUserProfileRepository>();
+			_unitOfWorkMock = new Mock<IUnitOfWork>();
 
-            _projectInvitationService = new ProjectInvitationService(
-                _unitOfWorkMock.Object,
-                _userManagerMock.Object
-            );
-#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
-        }
+			// Create UserManager mock using a helper method
+			var store = new Mock<IUserStore<IdentityUser>>();
+			_userManagerMock = new Mock<UserManager<IdentityUser>>(
+				store.Object, null, null, null, null, null, null, null, null
+			);
 
-        [Fact]
-        public async Task GetByIdAsync_ReturnsInvitation_WhenExists()
-        {
-            // Arrange
-            var invitationId = 1;
-            var mockInvitation = new ProjectInvitation { Id = invitationId };
+			_projectInvitationService = new ProjectInvitationService(
+				_projectInvitationRepositoryMock.Object,
+				_projectMemberRepositoryMock.Object,
+				_userProfileRepositoryMock.Object,
+				_unitOfWorkMock.Object,
+				_userManagerMock.Object
+			);
+		}
 
-            _unitOfWorkMock.Setup(x => x.ProjectInvitations.GetByIdAsync(invitationId))
-                           .ReturnsAsync(mockInvitation);
+		[Fact]
+		public async Task GetByIdAsync_ReturnsInvitation_WhenExists()
+		{
+			// Arrange
+			var invitationId = 1;
+			var mockInvitation = new ProjectInvitation { Id = invitationId };
 
-            // Act
-            var result = await _projectInvitationService.GetByIdAsync(invitationId);
+			_projectInvitationRepositoryMock.Setup(x => x.GetByIdAsync(invitationId))
+						   .ReturnsAsync(mockInvitation);
 
-            // Assert
-            Assert.NotNull(result);
-            Assert.Equal(invitationId, result!.Id);
-            _unitOfWorkMock.Verify(x => x.ProjectInvitations.GetByIdAsync(invitationId), Times.Once);
-        }
+			// Act
+			var result = await _projectInvitationService.GetByIdAsync(invitationId);
 
-        [Fact]
-        public async Task GetByIdAsync_ReturnsNull_WhenInvitationDoesNotExist()
-        {
-            // Arrange
-            var invitationId = 999;
+			// Assert
+			Assert.NotNull(result);
+			Assert.Equal(invitationId, result!.Id);
+			_projectInvitationRepositoryMock.Verify(x => x.GetByIdAsync(invitationId), Times.Once);
+		}
 
-            _unitOfWorkMock.Setup(x => x.ProjectInvitations.GetByIdAsync(invitationId))
-                           .ReturnsAsync((ProjectInvitation?)null);
+		[Fact]
+		public async Task GetByIdAsync_ReturnsNull_WhenInvitationDoesNotExist()
+		{
+			// Arrange
+			var invitationId = 999;
 
-            // Act
-            var result = await _projectInvitationService.GetByIdAsync(invitationId);
+			_projectInvitationRepositoryMock.Setup(x => x.GetByIdAsync(invitationId))
+						   .ReturnsAsync((ProjectInvitation?)null);
 
-            // Assert
-            Assert.Null(result);
-            _unitOfWorkMock.Verify(x => x.ProjectInvitations.GetByIdAsync(invitationId), Times.Once);
-        }
+			// Act
+			var result = await _projectInvitationService.GetByIdAsync(invitationId);
 
-        [Fact]
-        public async Task GetByIdAsync_ShouldThrowException_WhenRepositoryThrows()
-        {
-            // Arrange
-            var invitationId = 1;
+			// Assert
+			Assert.Null(result);
+			_projectInvitationRepositoryMock.Verify(x => x.GetByIdAsync(invitationId), Times.Once);
+		}
 
-            _unitOfWorkMock
-                .Setup(u => u.ProjectInvitations.GetByIdAsync(invitationId))
-                .ThrowsAsync(new Exception("Database error"));
+		[Fact]
+		public async Task GetByIdAsync_ShouldThrowException_WhenRepositoryThrows()
+		{
+			// Arrange
+			var invitationId = 1;
 
-            // Act & Assert
-            await Assert.ThrowsAsync<Exception>(() =>
-                _projectInvitationService.GetByIdAsync(invitationId));
-        }
+			_projectInvitationRepositoryMock.Setup(u => u.GetByIdAsync(invitationId))
+				.ThrowsAsync(new Exception("Database error"));
 
-        [Fact]
-        public async Task GetInvitationListAsync_ReturnsPaginatedInvitations()
-        {
-            // Arrange
-            var projectId = 1;
-            var pageIndex = 1;
-            var pageSize = 2;
-            var skip = (pageIndex - 1) * pageSize;
-            var totalCount = 5;
+			// Act & Assert
+			await Assert.ThrowsAsync<Exception>(() =>
+				_projectInvitationService.GetByIdAsync(invitationId));
+		}
 
-            var mockInvitations = new List<ProjectInvitation>
-            {
-                new ProjectInvitation
-                {
-                    Id = 1,
-                    ProjectId = projectId,
-                    InvitedUserProfile = new UserProfile
-                    {
-                        Id = 10,
-                        User = new IdentityUser { UserName = "testuser1" }
-                    }
-                },
-                new ProjectInvitation
-                {
-                    Id = 2,
-                    ProjectId = projectId,
-                    InvitedUserProfile = new UserProfile
-                    {
-                        Id = 11,
-                        User = new IdentityUser { UserName = "testuser2" }
-                    }
-                }
+		[Fact]
+		public async Task GetInvitationListAsync_ReturnsPaginatedInvitations()
+		{
+			// Arrange
+			var projectId = 1;
+			var pageIndex = 1;
+			var pageSize = 2;
+			var skip = (pageIndex - 1) * pageSize;
+			var totalCount = 5;
+
+			var mockInvitations = new List<ProjectInvitation>
+			{
+				new ProjectInvitation
+				{
+					Id = 1,
+					ProjectId = projectId,
+					InvitedUserProfile = new UserProfile
+					{
+						Id = 10,
+						User = new IdentityUser { UserName = "testuser1" }
+					}
+				},
+				new ProjectInvitation
+				{
+					Id = 2,
+					ProjectId = projectId,
+					InvitedUserProfile = new UserProfile
+					{
+						Id = 11,
+						User = new IdentityUser { UserName = "testuser2" }
+					}
+				}
+			};
+
+			// Setup must match: predicate, orderBy, includes, take, skip
+			_projectInvitationRepositoryMock.Setup(u => u.GetPaginatedListAsync(
+					It.Is<Expression<Func<ProjectInvitation, bool>>>(pred => pred.Compile()(mockInvitations[0])),
+					It.IsAny<Func<IQueryable<ProjectInvitation>, IOrderedQueryable<ProjectInvitation>>>(),
+					It.IsAny<Func<IQueryable<ProjectInvitation>, IQueryable<ProjectInvitation>>>(),
+					pageSize,
+					skip
+				))
+				.ReturnsAsync((mockInvitations.AsEnumerable(), totalCount));
+
+			// Act
+			var result = await _projectInvitationService.GetInvitationListAsync(projectId, pageIndex, pageSize);
+
+			// Assert
+			Assert.NotNull(result);
+			Assert.Equal(totalCount, result.TotalCount);
+			Assert.Equal(mockInvitations.Count, result.Items.Count);
+			Assert.Equal("testuser1", result.Items[0].InvitedUserProfile.User.UserName);
+
+			_projectInvitationRepositoryMock.Verify(u => u.GetPaginatedListAsync(
+				It.IsAny<Expression<Func<ProjectInvitation, bool>>>(),
+				It.IsAny<Func<IQueryable<ProjectInvitation>, IOrderedQueryable<ProjectInvitation>>>(),
+				It.IsAny<Func<IQueryable<ProjectInvitation>, IQueryable<ProjectInvitation>>>(),
+				pageSize,
+				skip
+			), Times.Once);
+		}
+
+		[Fact]
+		public async Task GetInvitationListAsync_ReturnsEmpty_WhenNoInvitations()
+		{
+			// Arrange
+			var projectId = 1;
+			var pageIndex = 1;
+			var pageSize = 2;
+			var skip = (pageIndex - 1) * pageSize;
+
+			_projectInvitationRepositoryMock.Setup(u => u.GetPaginatedListAsync(
+					It.IsAny<Expression<Func<ProjectInvitation, bool>>>(),
+					null,
+					It.IsAny<Func<IQueryable<ProjectInvitation>, IQueryable<ProjectInvitation>>>(),
+					pageSize,
+					skip
+				))
+				.ReturnsAsync((Enumerable.Empty<ProjectInvitation>(), 0));
+
+			// Act
+			var result = await _projectInvitationService.GetInvitationListAsync(projectId, pageIndex, pageSize);
+
+			// Assert
+			Assert.Empty(result.Items);
+			Assert.Equal(0, result.TotalCount);
+			Assert.False(result.HasPreviousPage, "On first page, HasPreviousPage should be false");
+			Assert.False(result.HasNextPage, "With no items, HasNextPage should be false");
+
+			_projectInvitationRepositoryMock.Verify(u => u.GetPaginatedListAsync(
+				It.IsAny<Expression<Func<ProjectInvitation, bool>>>(),
+				null,
+				It.IsAny<Func<IQueryable<ProjectInvitation>, IQueryable<ProjectInvitation>>>(),
+				pageSize,
+				skip
+			), Times.Once);
+		}
+
+		[Fact]
+		public async Task GetInvitationListAsync_SetsHasPreviousAndNext_OnMiddlePage()
+		{
+			// Arrange
+			var projectId = 1;
+			var pageIndex = 2;
+			var pageSize = 2;
+			var skip = (pageIndex - 1) * pageSize;
+
+			// Simulate 2 items on page 2, total 5 ⇒ totalPages = 3
+			var mockInvitations = new[]
+			{
+				new ProjectInvitation { Id = 3, ProjectId = projectId },
+				new ProjectInvitation { Id = 4, ProjectId = projectId }
+			};
+			var totalCount = 5;
+
+			_projectInvitationRepositoryMock.Setup(u => u.GetPaginatedListAsync(
+					It.IsAny<Expression<Func<ProjectInvitation, bool>>>(),
+					null,
+					It.IsAny<Func<IQueryable<ProjectInvitation>, IQueryable<ProjectInvitation>>>(),
+					pageSize,
+					skip
+				))
+				.ReturnsAsync((mockInvitations.AsEnumerable(), totalCount));
+
+			// Act
+			var result = await _projectInvitationService.GetInvitationListAsync(projectId, pageIndex, pageSize);
+
+			// Assert
+			Assert.Equal(2, result.Items.Count);
+			Assert.Equal(5, result.TotalCount);
+			Assert.True(result.HasPreviousPage, "PageIndex 2 > 1 => HasPreviousPage should be true");
+			Assert.True(result.HasNextPage, "PageIndex 2 < TotalPages (3) => HasNextPage should be true");
+		}
+
+		[Fact]
+		public async Task GetInvitationListAsync_Works_WhenIncludesNullInRepository()
+		{
+			// Arrange
+			var projectId = 50;
+			var pageIndex = 2;
+			var pageSize = 5;
+			var skip = (pageIndex - 1) * pageSize;
+
+			var items = new[] { new ProjectInvitation { Id = 99, ProjectId = projectId } };
+			var count = 1;
+
+			_projectInvitationRepositoryMock.Setup(u => u.GetPaginatedListAsync(
+				  It.IsAny<Expression<Func<ProjectInvitation, bool>>>(),
+				  /* orderBy */  null,
+				  /* includes */ null,
+				  /* take */     pageSize,
+				  /* skip */     skip
+			  ))
+			  .ReturnsAsync((items.AsEnumerable(), count));
+
+			// Act
+			var (fetched, total) = await _projectInvitationRepositoryMock.Object
+			  .GetPaginatedListAsync(pi => pi.ProjectId == projectId, null, null, pageSize, skip);
+
+			// Assert
+			Assert.Equal(count, total);
+			Assert.Single(fetched);
+			Assert.Equal(99, fetched.First().Id);
+		}
+
+		[Fact]
+		public async Task GetInvitationListAsync_ShouldThrowException_WhenRepositoryFails()
+		{
+			// Arrange
+			var projectId = 1;
+			var pageIndex = 1;
+			var pageSize = 10;
+
+			_projectInvitationRepositoryMock.Setup(u => u.GetPaginatedListAsync(
+					It.IsAny<Expression<Func<ProjectInvitation, bool>>>(),
+					null,
+					It.IsAny<Func<IQueryable<ProjectInvitation>, IQueryable<ProjectInvitation>>>(),
+					It.IsAny<int>(),
+					It.IsAny<int>()))
+				.ThrowsAsync(new Exception("Repository failure"));
+
+			// Act & Assert
+			await Assert.ThrowsAsync<Exception>(() =>
+				_projectInvitationService.GetInvitationListAsync(projectId, pageIndex, pageSize));
+		}
+
+		[Fact]
+		public async Task AddAsync_ShouldReturnFailure_WhenUserNotFound()
+		{
+			// Arrange
+			var email = "missing@user.com";
+			var projectId = 1;
+
+			_userManagerMock.Setup(x => x.FindByEmailAsync(email))
+							.ReturnsAsync((IdentityUser)null!);
+
+			// Act
+			var result = await _projectInvitationService.AddAsync(projectId, email, ProjectRole.Contributor);
+
+			// Assert
+			Assert.False(result.Success);
+			Assert.Equal("User not found.", result.Message);
+		}
+
+		[Fact]
+		public async Task AddAsync_ShouldReturnFailure_WhenUserProfileNotFound()
+		{
+			// Arrange
+			var email = "user@example.com";
+			var projectId = 1;
+			var userId = "user-123";
+
+			var identityUser = new IdentityUser
+			{
+				Id = userId,
+				Email = email,
+				UserName = "testuser"
+			};
+
+			_userManagerMock.Setup(x => x.FindByEmailAsync(email))
+				.ReturnsAsync(identityUser);
+
+			_userProfileRepositoryMock.Setup(x => x.FindByExpressionAsync(
+					It.IsAny<Expression<Func<UserProfile, bool>>>(),
+					null,
+					null,
+					null,
+					null))
+				.ReturnsAsync(new List<UserProfile>());
+
+			// Act
+			var result = await _projectInvitationService.AddAsync(projectId, email, ProjectRole.Contributor);
+
+			// Assert
+			Assert.False(result.Success);
+			Assert.Equal("User profile not found.", result.Message);
+		}
+
+		[Fact]
+		public async Task AddAsync_ShouldReturnFailure_WhenAlreadyProjectMemberExists()
+		{
+			// Arrange
+			var email = "user@example.com";
+			var projectId = 1;
+			var userId = "user-123";
+			var userProfileId = 10;
+
+			var identityUser = new IdentityUser
+			{
+				Id = userId,
+				Email = email,
+				UserName = "testuser"
+			};
+
+			var userProfile = new UserProfile
+			{
+				Id = userProfileId,
+				UserId = userId
+			};
+
+			var existingMember = new ProjectMember
+			{
+				ProjectId = projectId,
+				UserProfile = new UserProfile { UserId = userId }
+			};
+
+			_userManagerMock.Setup(x => x.FindByEmailAsync(email))
+				.ReturnsAsync(identityUser);
+
+			_userProfileRepositoryMock.Setup(x => x.FindByExpressionAsync(
+					It.IsAny<Expression<Func<UserProfile, bool>>>(),
+					null,
+					null,
+					null,
+					null))
+				.ReturnsAsync(new List<UserProfile> { userProfile });
+
+			_projectMemberRepositoryMock.Setup(x => x.FindByExpressionAsync(
+					It.IsAny<Expression<Func<ProjectMember, bool>>>(),
+					null,
+					null,
+					null,
+					null))
+				.ReturnsAsync(new List<ProjectMember> { existingMember });
+
+			// Act
+			var result = await _projectInvitationService.AddAsync(projectId, email, ProjectRole.Viewer);
+
+			// Assert
+			Assert.False(result.Success);
+			Assert.Equal("User is already a member of this project.", result.Message);
+		}
+
+		[Fact]
+		public async Task AddAsync_ShouldReturnFailure_WhenInvitationAlreadyExists()
+		{
+			// Arrange
+			var email = "user@example.com";
+			var projectId = 1;
+			var userId = "user-123";
+			var userProfileId = 10;
+
+			var identityUser = new IdentityUser
+			{
+				Id = userId,
+				Email = email,
+				UserName = "testuser"
+			};
+
+			var userProfile = new UserProfile
+			{
+				Id = userProfileId,
+				UserId = userId
+			};
+
+			var existingInvitation = new ProjectInvitation
+			{
+				ProjectId = projectId,
+				InvitedUserProfileId = userProfileId,
+				Status = InvitationStatus.Pending
+			};
+
+			_userManagerMock.Setup(x => x.FindByEmailAsync(email))
+				.ReturnsAsync(identityUser);
+
+			_userProfileRepositoryMock.Setup(x => x.FindByExpressionAsync(
+					It.IsAny<Expression<Func<UserProfile, bool>>>(),
+					null, null, null, null))
+				.ReturnsAsync(new List<UserProfile> { userProfile });
+
+			_projectMemberRepositoryMock.Setup(x => x.FindByExpressionAsync(
+					It.IsAny<Expression<Func<ProjectMember, bool>>>(),
+					null, null, null, null))
+				.ReturnsAsync(new List<ProjectMember>()); // user is not already a member
+
+			_projectInvitationRepositoryMock.Setup(x => x.FindByExpressionAsync(
+					It.IsAny<Expression<Func<ProjectInvitation, bool>>>(),
+					null, null, null, null))
+				.ReturnsAsync(new List<ProjectInvitation> { existingInvitation });
+
+			// Act
+			var result = await _projectInvitationService.AddAsync(projectId, email, ProjectRole.Contributor);
+
+			// Assert
+			Assert.False(result.Success);
+			Assert.Equal("An invitation has already been sent to this user.", result.Message);
+		}
+
+		[Fact]
+		public async Task AddAsync_ShouldReturnSuccess_WhenAllValidationsPass()
+		{
+			// Arrange
+			var email = "user@example.com";
+			var projectId = 1;
+			var userId = "user-123";
+			var userProfileId = 10;
+
+			var identityUser = new IdentityUser
+			{
+				Id = userId,
+				Email = email,
+				UserName = "testuser"
+			};
+
+			var userProfile = new UserProfile
+			{
+				Id = userProfileId,
+				UserId = userId
+			};
+
+			_userManagerMock.Setup(x => x.FindByEmailAsync(email))
+				.ReturnsAsync(identityUser);
+
+			_userProfileRepositoryMock.Setup(x => x.FindByExpressionAsync(
+					It.IsAny<Expression<Func<UserProfile, bool>>>(),
+					null, null, null, null))
+				.ReturnsAsync(new List<UserProfile> { userProfile });
+
+			_projectMemberRepositoryMock.Setup(x => x.FindByExpressionAsync(
+					It.IsAny<Expression<Func<ProjectMember, bool>>>(),
+					null, null, null, null))
+				.ReturnsAsync(new List<ProjectMember>()); // user is not a member
+
+			_projectInvitationRepositoryMock.Setup(x => x.FindByExpressionAsync(
+					It.IsAny<Expression<Func<ProjectInvitation, bool>>>(),
+					null, null, null, null))
+				.ReturnsAsync(new List<ProjectInvitation>()); // no pending invitation
+
+			_projectInvitationRepositoryMock.Setup(x => x.AddAsync(It.IsAny<ProjectInvitation>()))
+				.Returns(Task.CompletedTask);
+
+			_unitOfWorkMock.Setup(x => x.SaveChangesAsync())
+				.ReturnsAsync(1); // simulate successful DB save
+
+			// Act
+			var result = await _projectInvitationService.AddAsync(projectId, email, ProjectRole.Contributor);
+
+			// Assert
+			Assert.True(result.Success);
+			Assert.Equal("Invitation sent successfully.", result.Message);
+		}
+
+		[Fact]
+		public async Task AddAsync_ShouldThrowException_WhenUserManagerThrows()
+		{
+			// Arrange
+			var email = "user@example.com";
+			var projectId = 1;
+			var role = ProjectRole.Viewer;
+
+			_userManagerMock.Setup(um => um.FindByEmailAsync(email))
+				.ThrowsAsync(new Exception("UserManager failure"));
+
+			// Act & Assert
+			var exception = await Assert.ThrowsAsync<Exception>(() =>
+				_projectInvitationService.AddAsync(projectId, email, role));
+
+			Assert.Equal("UserManager failure", exception.Message);
+		}
+
+		[Fact]
+		public async Task UpdateInvitationStatusAsync_ShouldDoNothing_WhenInvitationNotFound()
+		{
+			// Arrange
+			var invitationId = 1;
+			_projectInvitationRepositoryMock.Setup(u => u.GetByIdAsync(invitationId))
+				.ReturnsAsync((ProjectInvitation)null!);
+
+			// Act
+			await _projectInvitationService.UpdateInvitationStatusAsync(invitationId, InvitationStatus.Accepted);
+
+			// Assert
+			_projectInvitationRepositoryMock.Verify(u => u.UpdateAsync(It.IsAny<ProjectInvitation>()), Times.Never);
+			_unitOfWorkMock.Verify(u => u.SaveChangesAsync(), Times.Never);
+		}
+
+		[Fact]
+		public async Task UpdateInvitationStatusAsync_ShouldAcceptInvitation_AndAddProjectMember()
+		{
+			// Arrange
+			var invitationId = 2;
+			var invitation = new ProjectInvitation
+			{
+				Id = invitationId,
+				ProjectId = 1,
+				InvitedUserProfileId = 10,
+				AssignedRole = ProjectRole.Contributor,
+				Status = InvitationStatus.Pending
+			};
+
+			_projectInvitationRepositoryMock.Setup(u => u.GetByIdAsync(invitationId))
+				.ReturnsAsync(invitation);
+
+			// Act
+			await _projectInvitationService.UpdateInvitationStatusAsync(invitationId, InvitationStatus.Accepted);
+
+			// Assert
+			Assert.Equal(InvitationStatus.Accepted, invitation.Status);
+			Assert.NotNull(invitation.AcceptedDate);
+			Assert.Null(invitation.DeclinedDate);
+
+			_projectMemberRepositoryMock.Verify(r => r.AddAsync(It.Is<ProjectMember>(
+				m => m.ProjectId == invitation.ProjectId &&
+				     m.UserProfileId == invitation.InvitedUserProfileId &&
+				     m.Role == invitation.AssignedRole)), Times.Once);
+
+			_projectInvitationRepositoryMock.Verify(u => u.UpdateAsync(invitation), Times.Once);
+			_unitOfWorkMock.Verify(u => u.SaveChangesAsync(), Times.Once);
+		}
+
+
+		[Fact]
+		public async Task UpdateInvitationStatusAsync_ShouldDeclineInvitation()
+		{
+			// Arrange
+			var invitationId = 3;
+			var invitation = new ProjectInvitation
+			{
+				Id = invitationId,
+				ProjectId = 1,
+				InvitedUserProfileId = 10,
+				AssignedRole = ProjectRole.Contributor,
+				Status = InvitationStatus.Pending,
+				AcceptedDate = DateTime.UtcNow // Simulate previously accepted
+			};
+
+			_projectInvitationRepositoryMock.Setup(u => u.GetByIdAsync(invitationId))
+				.ReturnsAsync(invitation);
+
+			// Act
+			await _projectInvitationService.UpdateInvitationStatusAsync(invitationId, InvitationStatus.Declined);
+
+			// Assert
+			Assert.Equal(InvitationStatus.Declined, invitation.Status);
+			Assert.Null(invitation.AcceptedDate);
+			Assert.NotNull(invitation.DeclinedDate);
+
+			_projectMemberRepositoryMock.Verify(u => u.AddAsync(It.IsAny<ProjectMember>()), Times.Never);
+			_projectInvitationRepositoryMock.Verify(u => u.UpdateAsync(invitation), Times.Once);
+			_unitOfWorkMock.Verify(u => u.SaveChangesAsync(), Times.Once);
+		}
+
+		[Fact]
+		public async Task UpdateInvitationStatusAsync_ShouldThrowException_WhenSaveFails()
+		{
+			// Arrange
+			var invitationId = 1;
+			var status = InvitationStatus.Accepted;
+
+			var invitation = new ProjectInvitation
+			{
+				Id = invitationId,
+				Status = InvitationStatus.Pending,
+				InvitedUserProfileId = 123,
+				ProjectId = 456
+			};
+
+			_projectInvitationRepositoryMock.Setup(u => u.GetByIdAsync(invitationId))
+				.ReturnsAsync(invitation);
+
+			_projectMemberRepositoryMock.Setup(u => u.AddAsync(It.IsAny<ProjectMember>()));
+
+			_unitOfWorkMock.Setup(u => u.SaveChangesAsync())
+				.ThrowsAsync(new Exception("Database save failed"));
+
+			// Act & Assert
+			await Assert.ThrowsAsync<Exception>(() =>
+				_projectInvitationService.UpdateInvitationStatusAsync(invitationId, status));
+		}
+
+		[Fact]
+		public async Task GetInvitationsForUserAsync_ShouldReturnEmpty_WhenUserProfileIdIsNull()
+		{
+			// Act
+			var result = await _projectInvitationService.GetInvitationsForUserAsync(null, 1, 10);
+
+			// Assert
+			Assert.NotNull(result);
+			Assert.Empty(result.Items);
+			Assert.Equal(0, result.TotalCount);
+		}
+
+		[Fact]
+		public async Task GetInvitationsForUserAsync_ShouldReturnPaginatedInvitations_WhenUserProfileIdIsValid()
+		{
+			// Arrange
+			var userProfileId = 1;
+			var pageIndex = 2;
+			var pageSize = 2;
+
+			var allInvitations = new List<ProjectInvitation>
+			{
+				new ProjectInvitation { Id = 1, InvitedUserProfileId = userProfileId },
+				new ProjectInvitation { Id = 2, InvitedUserProfileId = userProfileId },
+				new ProjectInvitation { Id = 3, InvitedUserProfileId = 99 } // should be filtered out
             };
 
-            // Setup must match: predicate, orderBy, includes, take, skip
-            _unitOfWorkMock
-                .Setup(u => u.ProjectInvitations.GetPaginatedListAsync(
-                    It.Is<Expression<Func<ProjectInvitation, bool>>>(pred => pred.Compile()(mockInvitations[0])),
-                    It.IsAny<Func<IQueryable<ProjectInvitation>, IOrderedQueryable<ProjectInvitation>>>(),
-                    It.IsAny<Func<IQueryable<ProjectInvitation>, IQueryable<ProjectInvitation>>>(),
-                    pageSize,
-                    skip
-                ))
-                .ReturnsAsync((mockInvitations.AsEnumerable(), totalCount));
-
-            // Act
-            var result = await _projectInvitationService.GetInvitationListAsync(projectId, pageIndex, pageSize);
-
-            // Assert
-            Assert.NotNull(result);
-            Assert.Equal(totalCount, result.TotalCount);
-            Assert.Equal(mockInvitations.Count, result.Items.Count);
-            Assert.Equal("testuser1", result.Items[0].InvitedUserProfile.User.UserName);
-
-            _unitOfWorkMock.Verify(u => u.ProjectInvitations.GetPaginatedListAsync(
-                It.IsAny<Expression<Func<ProjectInvitation, bool>>>(),
-                It.IsAny<Func<IQueryable<ProjectInvitation>, IOrderedQueryable<ProjectInvitation>>>(),
-                It.IsAny<Func<IQueryable<ProjectInvitation>, IQueryable<ProjectInvitation>>>(),
-                pageSize,
-                skip
-            ), Times.Once);
-        }
-
-        [Fact]
-        public async Task GetInvitationListAsync_ReturnsEmpty_WhenNoInvitations()
-        {
-            // Arrange
-            var projectId = 1;
-            var pageIndex = 1;
-            var pageSize = 2;
-            var skip = (pageIndex - 1) * pageSize;
-
-            _unitOfWorkMock.Setup(u => u.ProjectInvitations.GetPaginatedListAsync(
-                    It.IsAny<Expression<Func<ProjectInvitation, bool>>>(),
-                    null,
-                    It.IsAny<Func<IQueryable<ProjectInvitation>, IQueryable<ProjectInvitation>>>(),
-                    pageSize,
-                    skip
-                ))
-                .ReturnsAsync((Enumerable.Empty<ProjectInvitation>(), 0));
-
-            // Act
-            var result = await _projectInvitationService.GetInvitationListAsync(projectId, pageIndex, pageSize);
-
-            // Assert
-            Assert.Empty(result.Items);
-            Assert.Equal(0, result.TotalCount);
-            Assert.False(result.HasPreviousPage, "On first page, HasPreviousPage should be false");
-            Assert.False(result.HasNextPage, "With no items, HasNextPage should be false");
-
-            _unitOfWorkMock.Verify(u => u.ProjectInvitations.GetPaginatedListAsync(
-                It.IsAny<Expression<Func<ProjectInvitation, bool>>>(),
-                null,
-                It.IsAny<Func<IQueryable<ProjectInvitation>, IQueryable<ProjectInvitation>>>(),
-                pageSize,
-                skip
-            ), Times.Once);
-        }
-
-        [Fact]
-        public async Task GetInvitationListAsync_SetsHasPreviousAndNext_OnMiddlePage()
-        {
-            // Arrange
-            var projectId = 1;
-            var pageIndex = 2;
-            var pageSize = 2;
-            var skip = (pageIndex - 1) * pageSize;
-
-            // Simulate 2 items on page 2, total 5 ⇒ totalPages = 3
-            var mockInvitations = new[]
-            {
-                new ProjectInvitation { Id = 3, ProjectId = projectId },
-                new ProjectInvitation { Id = 4, ProjectId = projectId }
-            };
-            var totalCount = 5;
-
-            _unitOfWorkMock
-                .Setup(u => u.ProjectInvitations.GetPaginatedListAsync(
-                    It.IsAny<Expression<Func<ProjectInvitation, bool>>>(),
-                    null,
-                    It.IsAny<Func<IQueryable<ProjectInvitation>, IQueryable<ProjectInvitation>>>(),
-                    pageSize,
-                    skip
-                ))
-                .ReturnsAsync((mockInvitations.AsEnumerable(), totalCount));
-
-            // Act
-            var result = await _projectInvitationService.GetInvitationListAsync(projectId, pageIndex, pageSize);
-
-            // Assert
-            Assert.Equal(2, result.Items.Count);
-            Assert.Equal(5, result.TotalCount);
-            Assert.True(result.HasPreviousPage, "PageIndex 2 > 1 => HasPreviousPage should be true");
-            Assert.True(result.HasNextPage, "PageIndex 2 < TotalPages (3) => HasNextPage should be true");
-        }
-
-        [Fact]
-        public async Task GetInvitationListAsync_Works_WhenIncludesNullInRepository()
-        {
-            // Arrange
-            var projectId = 50;
-            var pageIndex = 2;
-            var pageSize = 5;
-            var skip = (pageIndex - 1) * pageSize;
-
-            var items = new[] { new ProjectInvitation { Id = 99, ProjectId = projectId } };
-            var count = 1;
-
-            _unitOfWorkMock
-              .Setup(u => u.ProjectInvitations.GetPaginatedListAsync(
-                  It.IsAny<Expression<Func<ProjectInvitation, bool>>>(),
-                  /* orderBy */  null,
-                  /* includes */ null,
-                  /* take */     pageSize,
-                  /* skip */     skip
-              ))
-              .ReturnsAsync((items.AsEnumerable(), count));
-
-            // Act
-            var (fetched, total) = await _unitOfWorkMock.Object
-              .ProjectInvitations
-              .GetPaginatedListAsync(pi => pi.ProjectId == projectId, null, null, pageSize, skip);
-
-            // Assert
-            Assert.Equal(count, total);
-            Assert.Single(fetched);
-            Assert.Equal(99, fetched.First().Id);
-        }
-
-        [Fact]
-        public async Task GetInvitationListAsync_ShouldThrowException_WhenRepositoryFails()
-        {
-            // Arrange
-            var projectId = 1;
-            var pageIndex = 1;
-            var pageSize = 10;
-
-            _unitOfWorkMock
-                .Setup(u => u.ProjectInvitations.GetPaginatedListAsync(
-                    It.IsAny<Expression<Func<ProjectInvitation, bool>>>(),
-                    null,
-                    It.IsAny<Func<IQueryable<ProjectInvitation>, IQueryable<ProjectInvitation>>>(),
-                    It.IsAny<int>(),
-                    It.IsAny<int>()))
-                .ThrowsAsync(new Exception("Repository failure"));
-
-            // Act & Assert
-            await Assert.ThrowsAsync<Exception>(() =>
-                _projectInvitationService.GetInvitationListAsync(projectId, pageIndex, pageSize));
-        }
-
-        [Fact]
-        public async Task AddAsync_ShouldReturnFailure_WhenUserNotFound()
-        {
-            // Arrange
-            var email = "missing@user.com";
-            var projectId = 1;
-
-            _userManagerMock.Setup(x => x.FindByEmailAsync(email))
-                            .ReturnsAsync((IdentityUser)null!);
-
-            // Act
-            var result = await _projectInvitationService.AddAsync(projectId, email, ProjectRole.Contributor);
-
-            // Assert
-            Assert.False(result.Success);
-            Assert.Equal("User not found.", result.Message);
-        }
-
-        [Fact]
-        public async Task AddAsync_ShouldReturnFailure_WhenUserProfileNotFound()
-        {
-            // Arrange
-            var email = "user@example.com";
-            var projectId = 1;
-            var userId = "user-123";
-
-            var identityUser = new IdentityUser
-            {
-                Id = userId,
-                Email = email,
-                UserName = "testuser"
-            };
-
-            _userManagerMock.Setup(x => x.FindByEmailAsync(email))
-                .ReturnsAsync(identityUser);
-
-            _unitOfWorkMock.Setup(x => x.UserProfiles.FindByExpressionAsync(
-                    It.IsAny<Expression<Func<UserProfile, bool>>>(),
-                    null,
-                    null,
-                    null,
-                    null))
-                .ReturnsAsync(new List<UserProfile>());
-
-            // Act
-            var result = await _projectInvitationService.AddAsync(projectId, email, ProjectRole.Contributor);
-
-            // Assert
-            Assert.False(result.Success);
-            Assert.Equal("User profile not found.", result.Message);
-        }
-
-        [Fact]
-        public async Task AddAsync_ShouldReturnFailure_WhenAlreadyProjectMemberExists()
-        {
-            // Arrange
-            var email = "user@example.com";
-            var projectId = 1;
-            var userId = "user-123";
-            var userProfileId = 10;
-
-            var identityUser = new IdentityUser
-            {
-                Id = userId,
-                Email = email,
-                UserName = "testuser"
-            };
-
-            var userProfile = new UserProfile
-            {
-                Id = userProfileId,
-                UserId = userId
-            };
-
-            var existingMember = new ProjectMember
-            {
-                ProjectId = projectId,
-                UserProfile = new UserProfile { UserId = userId }
-            };
-
-            _userManagerMock.Setup(x => x.FindByEmailAsync(email))
-                .ReturnsAsync(identityUser);
-
-            _unitOfWorkMock.Setup(x => x.UserProfiles.FindByExpressionAsync(
-                    It.IsAny<Expression<Func<UserProfile, bool>>>(),
-                    null,
-                    null,
-                    null,
-                    null))
-                .ReturnsAsync(new List<UserProfile> { userProfile });
-
-            _unitOfWorkMock.Setup(x => x.ProjectMembers.FindByExpressionAsync(
-                    It.IsAny<Expression<Func<ProjectMember, bool>>>(),
-                    null,
-                    null,
-                    null,
-                    null))
-                .ReturnsAsync(new List<ProjectMember> { existingMember });
-
-            // Act
-            var result = await _projectInvitationService.AddAsync(projectId, email, ProjectRole.Viewer);
-
-            // Assert
-            Assert.False(result.Success);
-            Assert.Equal("User is already a member of this project.", result.Message);
-        }
-
-        [Fact]
-        public async Task AddAsync_ShouldReturnFailure_WhenInvitationAlreadyExists()
-        {
-            // Arrange
-            var email = "user@example.com";
-            var projectId = 1;
-            var userId = "user-123";
-            var userProfileId = 10;
-
-            var identityUser = new IdentityUser
-            {
-                Id = userId,
-                Email = email,
-                UserName = "testuser"
-            };
-
-            var userProfile = new UserProfile
-            {
-                Id = userProfileId,
-                UserId = userId
-            };
-
-            var existingInvitation = new ProjectInvitation
-            {
-                ProjectId = projectId,
-                InvitedUserProfileId = userProfileId,
-                Status = InvitationStatus.Pending
-            };
-
-            _userManagerMock.Setup(x => x.FindByEmailAsync(email))
-                .ReturnsAsync(identityUser);
-
-            _unitOfWorkMock.Setup(x => x.UserProfiles.FindByExpressionAsync(
-                    It.IsAny<Expression<Func<UserProfile, bool>>>(),
-                    null, null, null, null))
-                .ReturnsAsync(new List<UserProfile> { userProfile });
-
-            _unitOfWorkMock.Setup(x => x.ProjectMembers.FindByExpressionAsync(
-                    It.IsAny<Expression<Func<ProjectMember, bool>>>(),
-                    null, null, null, null))
-                .ReturnsAsync(new List<ProjectMember>()); // user is not already a member
-
-            _unitOfWorkMock.Setup(x => x.ProjectInvitations.FindByExpressionAsync(
-                    It.IsAny<Expression<Func<ProjectInvitation, bool>>>(),
-                    null, null, null, null))
-                .ReturnsAsync(new List<ProjectInvitation> { existingInvitation });
-
-            // Act
-            var result = await _projectInvitationService.AddAsync(projectId, email, ProjectRole.Contributor);
-
-            // Assert
-            Assert.False(result.Success);
-            Assert.Equal("An invitation has already been sent to this user.", result.Message);
-        }
-
-        [Fact]
-        public async Task AddAsync_ShouldReturnSuccess_WhenAllValidationsPass()
-        {
-            // Arrange
-            var email = "user@example.com";
-            var projectId = 1;
-            var userId = "user-123";
-            var userProfileId = 10;
-
-            var identityUser = new IdentityUser
-            {
-                Id = userId,
-                Email = email,
-                UserName = "testuser"
-            };
-
-            var userProfile = new UserProfile
-            {
-                Id = userProfileId,
-                UserId = userId
-            };
-
-            _userManagerMock.Setup(x => x.FindByEmailAsync(email))
-                .ReturnsAsync(identityUser);
-
-            _unitOfWorkMock.Setup(x => x.UserProfiles.FindByExpressionAsync(
-                    It.IsAny<Expression<Func<UserProfile, bool>>>(),
-                    null, null, null, null))
-                .ReturnsAsync(new List<UserProfile> { userProfile });
-
-            _unitOfWorkMock.Setup(x => x.ProjectMembers.FindByExpressionAsync(
-                    It.IsAny<Expression<Func<ProjectMember, bool>>>(),
-                    null, null, null, null))
-                .ReturnsAsync(new List<ProjectMember>()); // user is not a member
-
-            _unitOfWorkMock.Setup(x => x.ProjectInvitations.FindByExpressionAsync(
-                    It.IsAny<Expression<Func<ProjectInvitation, bool>>>(),
-                    null, null, null, null))
-                .ReturnsAsync(new List<ProjectInvitation>()); // no pending invitation
-
-            _unitOfWorkMock.Setup(x => x.ProjectInvitations.AddAsync(It.IsAny<ProjectInvitation>()))
-                .Returns(Task.CompletedTask);
-
-            _unitOfWorkMock.Setup(x => x.SaveChangesAsync())
-                .ReturnsAsync(1); // simulate successful DB save
-
-            // Act
-            var result = await _projectInvitationService.AddAsync(projectId, email, ProjectRole.Contributor);
-
-            // Assert
-            Assert.True(result.Success);
-            Assert.Equal("Invitation sent successfully.", result.Message);
-        }
-
-        [Fact]
-        public async Task AddAsync_ShouldThrowException_WhenUserManagerThrows()
-        {
-            // Arrange
-            var email = "user@example.com";
-            var projectId = 1;
-            var role = ProjectRole.Viewer;
-
-            _userManagerMock.Setup(um => um.FindByEmailAsync(email))
-                .ThrowsAsync(new Exception("UserManager failure"));
-
-            // Act & Assert
-            var exception = await Assert.ThrowsAsync<Exception>(() =>
-                _projectInvitationService.AddAsync(projectId, email, role));
-
-            Assert.Equal("UserManager failure", exception.Message);
-        }
-
-        [Fact]
-        public async Task UpdateInvitationStatusAsync_ShouldDoNothing_WhenInvitationNotFound()
-        {
-            // Arrange
-            var invitationId = 1;
-            _unitOfWorkMock.Setup(u => u.ProjectInvitations.GetByIdAsync(invitationId))
-                .ReturnsAsync((ProjectInvitation)null!);
-
-            // Act
-            await _projectInvitationService.UpdateInvitationStatusAsync(invitationId, InvitationStatus.Accepted);
-
-            // Assert
-            _unitOfWorkMock.Verify(u => u.ProjectInvitations.UpdateAsync(It.IsAny<ProjectInvitation>()), Times.Never);
-            _unitOfWorkMock.Verify(u => u.SaveChangesAsync(), Times.Never);
-        }
-
-        [Fact]
-        public async Task UpdateInvitationStatusAsync_ShouldAcceptInvitation_AndAddProjectMember()
-        {
-            // Arrange
-            var invitationId = 2;
-            var invitation = new ProjectInvitation
-            {
-                Id = invitationId,
-                ProjectId = 1,
-                InvitedUserProfileId = 10,
-                AssignedRole = ProjectRole.Contributor,
-                Status = InvitationStatus.Pending
-            };
-
-            _unitOfWorkMock.Setup(u => u.ProjectInvitations.GetByIdAsync(invitationId))
-                .ReturnsAsync(invitation);
-
-            var projectMembersRepoMock = new Mock<IProjectMemberRepository>(); // Use the actual interface here
-            _unitOfWorkMock.Setup(u => u.ProjectMembers).Returns(projectMembersRepoMock.Object);
-
-            // Act
-            await _projectInvitationService.UpdateInvitationStatusAsync(invitationId, InvitationStatus.Accepted);
-
-            // Assert
-            Assert.Equal(InvitationStatus.Accepted, invitation.Status);
-            Assert.NotNull(invitation.AcceptedDate);
-            Assert.Null(invitation.DeclinedDate);
-
-            projectMembersRepoMock.Verify(r => r.AddAsync(It.Is<ProjectMember>(
-                m => m.ProjectId == invitation.ProjectId &&
-                     m.UserProfileId == invitation.InvitedUserProfileId &&
-                     m.Role == invitation.AssignedRole)), Times.Once);
-
-            _unitOfWorkMock.Verify(u => u.ProjectInvitations.UpdateAsync(invitation), Times.Once);
-            _unitOfWorkMock.Verify(u => u.SaveChangesAsync(), Times.Once);
-        }
-
-        [Fact]
-        public async Task UpdateInvitationStatusAsync_ShouldDeclineInvitation()
-        {
-            // Arrange
-            var invitationId = 3;
-            var invitation = new ProjectInvitation
-            {
-                Id = invitationId,
-                ProjectId = 1,
-                InvitedUserProfileId = 10,
-                AssignedRole = ProjectRole.Contributor,
-                Status = InvitationStatus.Pending,
-                AcceptedDate = DateTime.UtcNow // Simulate previously accepted
-            };
-
-            _unitOfWorkMock.Setup(u => u.ProjectInvitations.GetByIdAsync(invitationId))
-                .ReturnsAsync(invitation);
-
-            // Act
-            await _projectInvitationService.UpdateInvitationStatusAsync(invitationId, InvitationStatus.Declined);
-
-            // Assert
-            Assert.Equal(InvitationStatus.Declined, invitation.Status);
-            Assert.Null(invitation.AcceptedDate);
-            Assert.NotNull(invitation.DeclinedDate);
-
-            _unitOfWorkMock.Verify(u => u.ProjectMembers.AddAsync(It.IsAny<ProjectMember>()), Times.Never);
-            _unitOfWorkMock.Verify(u => u.ProjectInvitations.UpdateAsync(invitation), Times.Once);
-            _unitOfWorkMock.Verify(u => u.SaveChangesAsync(), Times.Once);
-        }
-
-        [Fact]
-        public async Task UpdateInvitationStatusAsync_ShouldThrowException_WhenSaveFails()
-        {
-            // Arrange
-            var invitationId = 1;
-            var status = InvitationStatus.Accepted;
-
-            var invitation = new ProjectInvitation
-            {
-                Id = invitationId,
-                Status = InvitationStatus.Pending,
-                InvitedUserProfileId = 123,
-                ProjectId = 456
-            };
-
-            _unitOfWorkMock.Setup(u => u.ProjectInvitations.GetByIdAsync(invitationId))
-                .ReturnsAsync(invitation);
-
-            _unitOfWorkMock
-                .Setup(u => u.ProjectMembers.AddAsync(It.IsAny<ProjectMember>()));
-
-            _unitOfWorkMock.Setup(u => u.SaveChangesAsync())
-                .ThrowsAsync(new Exception("Database save failed"));
-
-            // Act & Assert
-            await Assert.ThrowsAsync<Exception>(() =>
-                _projectInvitationService.UpdateInvitationStatusAsync(invitationId, status));
-        }
-
-        [Fact]
-        public async Task GetInvitationsForUserAsync_ShouldReturnEmpty_WhenUserProfileIdIsNull()
-        {
-            // Act
-            var result = await _projectInvitationService.GetInvitationsForUserAsync(null, 1, 10);
-
-            // Assert
-            Assert.NotNull(result);
-            Assert.Empty(result.Items);
-            Assert.Equal(0, result.TotalCount);
-        }
-
-        [Fact]
-        public async Task GetInvitationsForUserAsync_ShouldReturnPaginatedInvitations_WhenUserProfileIdIsValid()
-        {
-            // Arrange
-            var userProfileId = 1;
-            var pageIndex = 2;
-            var pageSize = 2;
-
-            var allInvitations = new List<ProjectInvitation>
-            {
-                new ProjectInvitation { Id = 1, InvitedUserProfileId = userProfileId },
-                new ProjectInvitation { Id = 2, InvitedUserProfileId = userProfileId },
-                new ProjectInvitation { Id = 3, InvitedUserProfileId = 99 } // should be filtered out
-            };
-
-            var expectedFiltered = allInvitations
-                .Where(i => i.InvitedUserProfileId == userProfileId)
-                .ToList();
-
-            var expectedPaged = expectedFiltered
-                .Skip((pageIndex - 1) * pageSize)
-                .Take(pageSize)
-                .ToList();
-
-            // Mock setup with expression matching to ensure proper filtering
-            _unitOfWorkMock.Setup(u => u.ProjectInvitations.GetPaginatedListAsync(
-                    It.IsAny<Expression<Func<ProjectInvitation, bool>>>(),
-                    null,
-                    It.IsAny<Func<IQueryable<ProjectInvitation>, IQueryable<ProjectInvitation>>>(),
-                    (pageIndex - 1) * pageSize,
-                    pageSize))
-                .ReturnsAsync((expectedPaged, expectedFiltered.Count));
-            // Ensure mock returns paginated results
-
-            // Act
-            var result = await _projectInvitationService.GetInvitationsForUserAsync(userProfileId, pageIndex, pageSize);
-
-            // Assert
-            Assert.NotNull(result);
-            Assert.Equal(expectedPaged.Count, result.Items.Count);
-            Assert.Equal(expectedFiltered.Count, result.TotalCount);
-            Assert.All(result.Items, i => Assert.Equal(userProfileId, i.InvitedUserProfileId));
-        }
-
-        [Fact]
-        public async Task GetInvitationsForUserAsync_ShouldReturnEmptyList_WhenNoInvitationsExist()
-        {
-            // Arrange
-            var userProfileId = 99;
-            var pageIndex = 1;
-            var pageSize = 5;
-
-            _unitOfWorkMock.Setup(u => u.ProjectInvitations.GetPaginatedListAsync(
-                    It.IsAny<Expression<Func<ProjectInvitation, bool>>>(),
-                    null,
-                    It.IsAny<Func<IQueryable<ProjectInvitation>, IIncludableQueryable<ProjectInvitation, object>>>(),
-                    (pageIndex - 1) * pageSize,
-                    pageSize))
-                .ReturnsAsync((new List<ProjectInvitation>(), 0));
-
-            // Act
-            var result = await _projectInvitationService.GetInvitationsForUserAsync(userProfileId, pageIndex, pageSize);
-
-            // Assert
-            Assert.NotNull(result);
-            Assert.Empty(result.Items);
-            Assert.Equal(0, result.TotalCount);
-        }
-
-        [Fact]
-        public async Task GetInvitationsForUserAsync_SetsHasPreviousAndNext_OnMiddlePage()
-        {
-            // Arrange
-            var userProfileId = 1;
-            var pageIndex = 2;
-            var pageSize = 2;
-            var skip = (pageIndex - 1) * pageSize;
-            var totalCount = 5; // 3 pages in total
-
-            var mockInvitations = new List<ProjectInvitation>
-            {
-                new ProjectInvitation { Id = 3, InvitedUserProfileId = userProfileId },
-                new ProjectInvitation { Id = 4, InvitedUserProfileId = userProfileId }
-            };
-
-            _unitOfWorkMock
-                .Setup(u => u.ProjectInvitations.GetPaginatedListAsync(
-                    It.IsAny<Expression<Func<ProjectInvitation, bool>>>(),
-                    null,
-                    It.IsAny<Func<IQueryable<ProjectInvitation>, IQueryable<ProjectInvitation>>>(),
-                    skip,
-                    pageSize
-                ))
-                .ReturnsAsync((mockInvitations, totalCount));
-
-            // Act
-            var result = await _projectInvitationService.GetInvitationsForUserAsync(userProfileId, pageIndex, pageSize);
-
-            // Assert
-            Assert.Equal(2, result.Items.Count);
-            Assert.Equal(totalCount, result.TotalCount);
-            Assert.True(result.HasPreviousPage, "PageIndex > 1 => HasPreviousPage should be true");
-            Assert.True(result.HasNextPage, "PageIndex < TotalPages => HasNextPage should be true");
-        }
-
-    }
+			var expectedFiltered = allInvitations
+				.Where(i => i.InvitedUserProfileId == userProfileId)
+				.ToList();
+
+			var expectedPaged = expectedFiltered
+				.Skip((pageIndex - 1) * pageSize)
+				.Take(pageSize)
+				.ToList();
+
+			// Mock setup with expression matching to ensure proper filtering
+			_projectInvitationRepositoryMock.Setup(u => u.GetPaginatedListAsync(
+					It.IsAny<Expression<Func<ProjectInvitation, bool>>>(),
+					null,
+					It.IsAny<Func<IQueryable<ProjectInvitation>, IQueryable<ProjectInvitation>>>(),
+					(pageIndex - 1) * pageSize,
+					pageSize))
+				.ReturnsAsync((expectedPaged, expectedFiltered.Count));
+			// Ensure mock returns paginated results
+
+			// Act
+			var result = await _projectInvitationService.GetInvitationsForUserAsync(userProfileId, pageIndex, pageSize);
+
+			// Assert
+			Assert.NotNull(result);
+			Assert.Equal(expectedPaged.Count, result.Items.Count);
+			Assert.Equal(expectedFiltered.Count, result.TotalCount);
+			Assert.All(result.Items, i => Assert.Equal(userProfileId, i.InvitedUserProfileId));
+		}
+
+		[Fact]
+		public async Task GetInvitationsForUserAsync_ShouldReturnEmptyList_WhenNoInvitationsExist()
+		{
+			// Arrange
+			var userProfileId = 99;
+			var pageIndex = 1;
+			var pageSize = 5;
+
+			_projectInvitationRepositoryMock.Setup(u => u.GetPaginatedListAsync(
+					It.IsAny<Expression<Func<ProjectInvitation, bool>>>(),
+					null,
+					It.IsAny<Func<IQueryable<ProjectInvitation>, IIncludableQueryable<ProjectInvitation, object>>>(),
+					(pageIndex - 1) * pageSize,
+					pageSize))
+				.ReturnsAsync((new List<ProjectInvitation>(), 0));
+
+			// Act
+			var result = await _projectInvitationService.GetInvitationsForUserAsync(userProfileId, pageIndex, pageSize);
+
+			// Assert
+			Assert.NotNull(result);
+			Assert.Empty(result.Items);
+			Assert.Equal(0, result.TotalCount);
+		}
+
+		[Fact]
+		public async Task GetInvitationsForUserAsync_SetsHasPreviousAndNext_OnMiddlePage()
+		{
+			// Arrange
+			var userProfileId = 1;
+			var pageIndex = 2;
+			var pageSize = 2;
+			var skip = (pageIndex - 1) * pageSize;
+			var totalCount = 5; // 3 pages in total
+
+			var mockInvitations = new List<ProjectInvitation>
+			{
+				new ProjectInvitation { Id = 3, InvitedUserProfileId = userProfileId },
+				new ProjectInvitation { Id = 4, InvitedUserProfileId = userProfileId }
+			};
+
+			_projectInvitationRepositoryMock.Setup(u => u.GetPaginatedListAsync(
+					It.IsAny<Expression<Func<ProjectInvitation, bool>>>(),
+					null,
+					It.IsAny<Func<IQueryable<ProjectInvitation>, IQueryable<ProjectInvitation>>>(),
+					skip,
+					pageSize
+				))
+				.ReturnsAsync((mockInvitations, totalCount));
+
+			// Act
+			var result = await _projectInvitationService.GetInvitationsForUserAsync(userProfileId, pageIndex, pageSize);
+
+			// Assert
+			Assert.Equal(2, result.Items.Count);
+			Assert.Equal(totalCount, result.TotalCount);
+			Assert.True(result.HasPreviousPage, "PageIndex > 1 => HasPreviousPage should be true");
+			Assert.True(result.HasNextPage, "PageIndex < TotalPages => HasNextPage should be true");
+		}
+
+	}
 }

--- a/TaskForge.NET/TaskForge.Tests/Application/Services/ProjectMemberServiceTests.cs
+++ b/TaskForge.NET/TaskForge.Tests/Application/Services/ProjectMemberServiceTests.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Identity;
 using Moq;
 using System.Linq.Expressions;
+using TaskForge.Application.Interfaces.Repositories;
 using TaskForge.Application.Interfaces.Repositories.Common;
 using TaskForge.Application.Services;
 using TaskForge.Domain.Entities;
@@ -11,13 +12,19 @@ namespace TaskForge.Tests.Application.Services
 {
     public class ProjectMemberServiceTests
     {
-        private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+	    private readonly Mock<IProjectInvitationRepository> _projectInvitationRepositoryMock;
+	    private readonly Mock<IProjectMemberRepository> _projectMemberRepositoryMock;
+	    private readonly Mock<IUserProfileRepository> _userProfileRepositoryMock;
+		private readonly Mock<IUnitOfWork> _unitOfWorkMock;
         private readonly ProjectMemberService _projectMemberService;
 
         public ProjectMemberServiceTests()
         {
             _unitOfWorkMock = new Mock<IUnitOfWork>();
-            _projectMemberService = new ProjectMemberService(_unitOfWorkMock.Object);
+            _projectInvitationRepositoryMock = new Mock<IProjectInvitationRepository>();
+            _projectMemberRepositoryMock = new Mock<IProjectMemberRepository>();
+            _userProfileRepositoryMock = new Mock<IUserProfileRepository>();
+			_projectMemberService = new ProjectMemberService(_projectMemberRepositoryMock.Object,_unitOfWorkMock.Object);
         }
 
         [Fact]
@@ -27,7 +34,7 @@ namespace TaskForge.Tests.Application.Services
             var memberId = 1;
             var expectedMember = new ProjectMember { Id = memberId, IsDeleted = false };
 
-            _unitOfWorkMock.Setup(u => u.ProjectMembers.GetByIdAsync(memberId))
+            _projectMemberRepositoryMock.Setup(u => u.GetByIdAsync(memberId))
                 .ReturnsAsync(expectedMember);
 
             // Act
@@ -44,7 +51,7 @@ namespace TaskForge.Tests.Application.Services
             // Arrange
             var invalidId = 999;
 
-            _unitOfWorkMock.Setup(u => u.ProjectMembers.GetByIdAsync(invalidId))
+            _projectMemberRepositoryMock.Setup(u => u.GetByIdAsync(invalidId))
                 .ReturnsAsync((ProjectMember?)null);
 
             // Act
@@ -60,7 +67,7 @@ namespace TaskForge.Tests.Application.Services
             // Arrange
             var memberId = 2;
 
-            _unitOfWorkMock.Setup(u => u.ProjectMembers.GetByIdAsync(memberId))
+            _projectMemberRepositoryMock.Setup(u => u.GetByIdAsync(memberId))
                 .ReturnsAsync((ProjectMember?)null); // Simulating soft-delete logic
 
             // Act
@@ -76,7 +83,7 @@ namespace TaskForge.Tests.Application.Services
             // Arrange
             var memberId = 3;
 
-            _unitOfWorkMock.Setup(u => u.ProjectMembers.GetByIdAsync(memberId))
+            _projectMemberRepositoryMock.Setup(u => u.GetByIdAsync(memberId))
                 .ThrowsAsync(new Exception("Database failure"));
 
             // Act & Assert
@@ -115,7 +122,7 @@ namespace TaskForge.Tests.Application.Services
                 Role = ProjectRole.Admin
             };
 
-            _unitOfWorkMock.Setup(u => u.ProjectMembers.FindByExpressionAsync(
+            _projectMemberRepositoryMock.Setup(u => u.FindByExpressionAsync(
                     It.IsAny<Expression<Func<ProjectMember, bool>>>(),
                     null,
                     It.IsAny<Func<IQueryable<ProjectMember>, IQueryable<ProjectMember>>>(),
@@ -140,7 +147,7 @@ namespace TaskForge.Tests.Application.Services
             string userId = "nonexistent-user";
             int projectId = 123;
 
-            _unitOfWorkMock.Setup(u => u.ProjectMembers.FindByExpressionAsync(
+            _projectMemberRepositoryMock.Setup(u => u.FindByExpressionAsync(
                     It.IsAny<Expression<Func<ProjectMember, bool>>>(),
                     null,
                     It.IsAny<Func<IQueryable<ProjectMember>, IQueryable<ProjectMember>>>(),
@@ -175,7 +182,7 @@ namespace TaskForge.Tests.Application.Services
             };
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 
-            _unitOfWorkMock.Setup(u => u.ProjectMembers.FindByExpressionAsync(
+            _projectMemberRepositoryMock.Setup(u => u.FindByExpressionAsync(
                     It.IsAny<Expression<Func<ProjectMember, bool>>>(),
                     null,
                     It.IsAny<Func<IQueryable<ProjectMember>, IQueryable<ProjectMember>>>(),
@@ -199,7 +206,7 @@ namespace TaskForge.Tests.Application.Services
             string userId = "user-1";
             int projectId = 1;
 
-            _unitOfWorkMock.Setup(u => u.ProjectMembers.FindByExpressionAsync(
+            _projectMemberRepositoryMock.Setup(u => u.FindByExpressionAsync(
                     It.IsAny<Expression<Func<ProjectMember, bool>>>(),
                     null,
                     It.IsAny<Func<IQueryable<ProjectMember>, IQueryable<ProjectMember>>>(),
@@ -231,7 +238,7 @@ namespace TaskForge.Tests.Application.Services
                 }
             };
 
-            _unitOfWorkMock.Setup(u => u.ProjectMembers.FindByExpressionAsync(
+            _projectMemberRepositoryMock.Setup(u => u.FindByExpressionAsync(
                     It.Is<Expression<Func<ProjectMember, bool>>>(predicate =>
                         predicate.Compile()(matchingMember)),
                     null,
@@ -268,7 +275,7 @@ namespace TaskForge.Tests.Application.Services
                 Role = ProjectRole.Contributor
             };
 
-            _unitOfWorkMock.Setup(u => u.ProjectMembers.FindByExpressionAsync(
+            _projectMemberRepositoryMock.Setup(u => u.FindByExpressionAsync(
                     It.IsAny<Expression<Func<ProjectMember, bool>>>(),
                     It.IsAny<Func<IQueryable<ProjectMember>, IOrderedQueryable<ProjectMember>>>(),
                     It.IsAny<Func<IQueryable<ProjectMember>, IQueryable<ProjectMember>>>(),
@@ -296,7 +303,7 @@ namespace TaskForge.Tests.Application.Services
             // Arrange
             int projectId = 999;
 
-            _unitOfWorkMock.Setup(u => u.ProjectMembers.FindByExpressionAsync(
+            _projectMemberRepositoryMock.Setup(u => u.FindByExpressionAsync(
                     It.IsAny<Expression<Func<ProjectMember, bool>>>(),
                     It.IsAny<Func<IQueryable<ProjectMember>, IOrderedQueryable<ProjectMember>>>(),
                     It.IsAny<Func<IQueryable<ProjectMember>, IQueryable<ProjectMember>>>(),
@@ -333,7 +340,7 @@ namespace TaskForge.Tests.Application.Services
             };
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 
-            _unitOfWorkMock.Setup(u => u.ProjectMembers.FindByExpressionAsync(
+            _projectMemberRepositoryMock.Setup(u => u.FindByExpressionAsync(
                     It.IsAny<Expression<Func<ProjectMember, bool>>>(),
                     It.IsAny<Func<IQueryable<ProjectMember>, IOrderedQueryable<ProjectMember>>>(),
                     It.IsAny<Func<IQueryable<ProjectMember>, IQueryable<ProjectMember>>>(),
@@ -374,7 +381,7 @@ namespace TaskForge.Tests.Application.Services
                 }
             };
 
-            _unitOfWorkMock.Setup(u => u.ProjectMembers.FindByExpressionAsync(
+            _projectMemberRepositoryMock.Setup(u => u.FindByExpressionAsync(
                     It.IsAny<Expression<Func<ProjectMember, bool>>>(),
                     It.IsAny<Func<IQueryable<ProjectMember>, IOrderedQueryable<ProjectMember>>>(),
                     It.IsAny<Func<IQueryable<ProjectMember>, IQueryable<ProjectMember>>>(),
@@ -399,7 +406,7 @@ namespace TaskForge.Tests.Application.Services
             // Arrange
             int projectId = 1;
 
-            _unitOfWorkMock.Setup(u => u.ProjectMembers.FindByExpressionAsync(
+            _projectMemberRepositoryMock.Setup(u => u.FindByExpressionAsync(
                     It.IsAny<Expression<Func<ProjectMember, bool>>>(),
                     It.IsAny<Func<IQueryable<ProjectMember>, IOrderedQueryable<ProjectMember>>>(),
                     It.IsAny<Func<IQueryable<ProjectMember>, IQueryable<ProjectMember>>>(),
@@ -419,7 +426,7 @@ namespace TaskForge.Tests.Application.Services
             var memberId = 1;
             var mockMember = new ProjectMember { Id = memberId, IsDeleted = false };
 
-            _unitOfWorkMock.Setup(u => u.ProjectMembers.DeleteByIdAsync(memberId))
+            _projectMemberRepositoryMock.Setup(u => u.DeleteByIdAsync(memberId))
                 .Returns(async () =>
                 {
                     mockMember.IsDeleted = true;
@@ -435,7 +442,7 @@ namespace TaskForge.Tests.Application.Services
 
             // Assert
             Assert.True(mockMember.IsDeleted);
-            _unitOfWorkMock.Verify(u => u.ProjectMembers.DeleteByIdAsync(memberId), Times.Once);
+            _projectMemberRepositoryMock.Verify(u => u.DeleteByIdAsync(memberId), Times.Once);
             _unitOfWorkMock.Verify(u => u.SaveChangesAsync(), Times.Once);
         }
 
@@ -445,7 +452,7 @@ namespace TaskForge.Tests.Application.Services
             // Arrange
             var memberId = 99;
 
-            _unitOfWorkMock.Setup(u => u.ProjectMembers.DeleteByIdAsync(memberId))
+            _projectMemberRepositoryMock.Setup(u => u.DeleteByIdAsync(memberId))
                 .Returns(Task.CompletedTask);
 
             _unitOfWorkMock.Setup(u => u.SaveChangesAsync()).ReturnsAsync(1);
@@ -453,7 +460,7 @@ namespace TaskForge.Tests.Application.Services
             // Act & Assert
             var exception = await Record.ExceptionAsync(() => _projectMemberService.RemoveAsync(memberId));
             Assert.Null(exception);
-            _unitOfWorkMock.Verify(u => u.ProjectMembers.DeleteByIdAsync(memberId), Times.Once);
+            _projectMemberRepositoryMock.Verify(u => u.DeleteByIdAsync(memberId), Times.Once);
             _unitOfWorkMock.Verify(u => u.SaveChangesAsync(), Times.Once);
         }
 
@@ -463,12 +470,12 @@ namespace TaskForge.Tests.Application.Services
             // Arrange
             var memberId = 1;
 
-            _unitOfWorkMock.Setup(u => u.ProjectMembers.DeleteByIdAsync(memberId))
+            _projectMemberRepositoryMock.Setup(u => u.DeleteByIdAsync(memberId))
                 .ThrowsAsync(new Exception("Deletion failed"));
 
             // Act & Assert
             await Assert.ThrowsAsync<Exception>(() => _projectMemberService.RemoveAsync(memberId));
-            _unitOfWorkMock.Verify(u => u.ProjectMembers.DeleteByIdAsync(memberId), Times.Once);
+            _projectMemberRepositoryMock.Verify(u => u.DeleteByIdAsync(memberId), Times.Once);
             _unitOfWorkMock.Verify(u => u.SaveChangesAsync(), Times.Never);
         }
 
@@ -478,7 +485,7 @@ namespace TaskForge.Tests.Application.Services
             // Arrange
             var memberId = 1;
 
-            _unitOfWorkMock.Setup(u => u.ProjectMembers.DeleteByIdAsync(memberId))
+            _projectMemberRepositoryMock.Setup(u => u.DeleteByIdAsync(memberId))
                 .Returns(Task.CompletedTask);
 
             _unitOfWorkMock.Setup(u => u.SaveChangesAsync())
@@ -486,7 +493,7 @@ namespace TaskForge.Tests.Application.Services
 
             // Act & Assert
             await Assert.ThrowsAsync<Exception>(() => _projectMemberService.RemoveAsync(memberId));
-            _unitOfWorkMock.Verify(u => u.ProjectMembers.DeleteByIdAsync(memberId), Times.Once);
+            _projectMemberRepositoryMock.Verify(u => u.DeleteByIdAsync(memberId), Times.Once);
             _unitOfWorkMock.Verify(u => u.SaveChangesAsync(), Times.Once);
         }
 
@@ -503,7 +510,7 @@ namespace TaskForge.Tests.Application.Services
                 new ProjectMember { ProjectId = 1, UserProfileId = userProfileId } // duplicate project
             };
 
-            _unitOfWorkMock.Setup(u => u.ProjectMembers.FindByExpressionAsync(
+            _projectMemberRepositoryMock.Setup(u => u.FindByExpressionAsync(
                 It.IsAny<Expression<Func<ProjectMember, bool>>>(),
                 null, null, null, null))
                 .ReturnsAsync(mockData);
@@ -522,7 +529,7 @@ namespace TaskForge.Tests.Application.Services
             int userProfileId = 10;
             var mockData = new List<ProjectMember>(); // empty list
 
-            _unitOfWorkMock.Setup(u => u.ProjectMembers.FindByExpressionAsync(
+            _projectMemberRepositoryMock.Setup(u => u.FindByExpressionAsync(
                 It.IsAny<Expression<Func<ProjectMember, bool>>>(),
                 null, null, null, null))
                 .ReturnsAsync(mockData);
@@ -538,7 +545,7 @@ namespace TaskForge.Tests.Application.Services
         public async Task GetUserProjectCountAsync_ShouldPropagateException_WhenRepositoryThrows()
         {
             // Arrange
-            _unitOfWorkMock.Setup(u => u.ProjectMembers.FindByExpressionAsync(
+            _projectMemberRepositoryMock.Setup(u => u.FindByExpressionAsync(
                 It.IsAny<Expression<Func<ProjectMember, bool>>>(),
                 null, null, null, null))
                 .ThrowsAsync(new Exception("DB error"));

--- a/TaskForge.NET/TaskForge.Tests/Application/Services/ProjectMemberServiceTests.cs
+++ b/TaskForge.NET/TaskForge.Tests/Application/Services/ProjectMemberServiceTests.cs
@@ -12,18 +12,14 @@ namespace TaskForge.Tests.Application.Services
 {
     public class ProjectMemberServiceTests
     {
-	    private readonly Mock<IProjectInvitationRepository> _projectInvitationRepositoryMock;
 	    private readonly Mock<IProjectMemberRepository> _projectMemberRepositoryMock;
-	    private readonly Mock<IUserProfileRepository> _userProfileRepositoryMock;
 		private readonly Mock<IUnitOfWork> _unitOfWorkMock;
         private readonly ProjectMemberService _projectMemberService;
 
         public ProjectMemberServiceTests()
         {
             _unitOfWorkMock = new Mock<IUnitOfWork>();
-            _projectInvitationRepositoryMock = new Mock<IProjectInvitationRepository>();
             _projectMemberRepositoryMock = new Mock<IProjectMemberRepository>();
-            _userProfileRepositoryMock = new Mock<IUserProfileRepository>();
 			_projectMemberService = new ProjectMemberService(_projectMemberRepositoryMock.Object,_unitOfWorkMock.Object);
         }
 

--- a/TaskForge.NET/TaskForge.Tests/Application/Services/UserProfileServiceTests.cs
+++ b/TaskForge.NET/TaskForge.Tests/Application/Services/UserProfileServiceTests.cs
@@ -18,10 +18,7 @@ namespace TaskForge.Tests.Application.Services
         {
             _mockUnitOfWork = new Mock<IUnitOfWork>();
             _mockUserProfileRepo = new Mock<IUserProfileRepository>();
-
-            _mockUnitOfWork.Setup(u => u.UserProfiles).Returns(_mockUserProfileRepo.Object);
-
-            _service = new UserProfileService(_mockUnitOfWork.Object);
+            _service = new UserProfileService(_mockUnitOfWork.Object, _mockUserProfileRepo.Object);
         }
 
         [Fact]

--- a/TaskForge.NET/TaskForge.Tests/Infrastructure/Repositories/Common/UnitOfWorkTests.cs
+++ b/TaskForge.NET/TaskForge.Tests/Infrastructure/Repositories/Common/UnitOfWorkTests.cs
@@ -10,7 +10,6 @@ namespace TaskForge.Tests.Infrastructure.Repositories.Common
 {
     public class UnitOfWorkTests
     {
-        private readonly Mock<IUserContextService> _mockUserContextService;
         private readonly TestApplicationDbContext _realContext;
         private readonly UnitOfWork _unitOfWork;
 
@@ -22,21 +21,12 @@ namespace TaskForge.Tests.Infrastructure.Repositories.Common
 
             _realContext = new TestApplicationDbContext(options);
 
-            _mockUserContextService = new Mock<IUserContextService>();
-
-            _unitOfWork = new UnitOfWork(_realContext, _mockUserContextService.Object);
+            _unitOfWork = new UnitOfWork(_realContext);
         }
 
         [Fact]
         public void Constructor_InitializesRepositories()
         {
-            Assert.NotNull(_unitOfWork.Projects);
-            Assert.NotNull(_unitOfWork.Tasks);
-            Assert.NotNull(_unitOfWork.ProjectMembers);
-            Assert.NotNull(_unitOfWork.ProjectInvitations);
-            Assert.NotNull(_unitOfWork.UserProfiles);
-            Assert.NotNull(_unitOfWork.TaskAttachments);
-            Assert.NotNull(_unitOfWork.TaskAssignments);
         }
 
         [Fact]
@@ -44,7 +34,7 @@ namespace TaskForge.Tests.Infrastructure.Repositories.Common
         {
             // Arrange
             var mockContext = new Mock<ApplicationDbContext>(new DbContextOptions<ApplicationDbContext>());
-            var unitOfWork = new UnitOfWork(mockContext.Object, _mockUserContextService.Object);
+            var unitOfWork = new UnitOfWork(mockContext.Object);
 
             // Act
             unitOfWork.Dispose();
@@ -58,7 +48,7 @@ namespace TaskForge.Tests.Infrastructure.Repositories.Common
         {
             // Arrange
             var mockContext = new Mock<ApplicationDbContext>(new DbContextOptions<ApplicationDbContext>());
-            var unitOfWork = new UnitOfWork(mockContext.Object, _mockUserContextService.Object);
+            var unitOfWork = new UnitOfWork(mockContext.Object);
 
             // Act
             unitOfWork.Dispose();
@@ -74,7 +64,7 @@ namespace TaskForge.Tests.Infrastructure.Repositories.Common
             // Arrange
             var mockContext = new Mock<ApplicationDbContext>(new DbContextOptions<ApplicationDbContext>());
             mockContext.Setup(m => m.SaveChangesAsync(default)).ReturnsAsync(42);
-            var unitOfWork = new UnitOfWork(mockContext.Object, _mockUserContextService.Object);
+            var unitOfWork = new UnitOfWork(mockContext.Object);
 
             // Act
             var result = await unitOfWork.SaveChangesAsync();

--- a/TaskForge.NET/TaskForge.Tests/Infrastructure/Repositories/Common/UnitOfWorkTests.cs
+++ b/TaskForge.NET/TaskForge.Tests/Infrastructure/Repositories/Common/UnitOfWorkTests.cs
@@ -25,11 +25,6 @@ namespace TaskForge.Tests.Infrastructure.Repositories.Common
         }
 
         [Fact]
-        public void Constructor_InitializesRepositories()
-        {
-        }
-
-        [Fact]
         public void Dispose_CallsContextDispose()
         {
             // Arrange


### PR DESCRIPTION
- Removed repository properties from UnitOfWork to enforce separation of concerns
- Retained only SaveChangesAsync and BeginTransactionAsync in UnitOfWork
- Injected required repositories directly into service constructors
- Updated service implementations and constructor dependencies accordingly
- Refactored all usages of the old UoW pattern using regex pattern search for consistency
- Ensured unit tests are updated and passing

Aligns with DDD and Clean Architecture best practices as recommended by mentor. Used regex-based search and replace to systematically apply the refactor across the solution.