### PR TITLE
refactor(file-service): make path validation and file operations cros…

### DIFF
--- a/TaskForge.NET/TaskForge.Application/Services/FileService.cs
+++ b/TaskForge.NET/TaskForge.Application/Services/FileService.cs
@@ -17,8 +17,9 @@ namespace TaskForge.Application.Services
 			if (string.IsNullOrWhiteSpace(relativePath))
 				throw new ArgumentException("Path cannot be null or empty.", nameof(relativePath));
 
-			if (Path.IsPathRooted(relativePath))
-				throw new ArgumentException("Absolute paths are not allowed.", nameof(relativePath));
+			// Check for any absolute path (both Windows and Unix style)
+			if (Path.IsPathRooted(relativePath) && !relativePath.StartsWith(_environment.WebRootPath, StringComparison.OrdinalIgnoreCase))
+				throw new ArgumentException("Absolute paths or path traversal is not allowed.", nameof(relativePath));
 
 			var combinedPath = Path.Combine(_environment.WebRootPath, relativePath);
 			var fullPath = Path.GetFullPath(combinedPath);


### PR DESCRIPTION
…s-platform compatible

- Modified ValidateAndGetAbsolutePath to handle path validation consistently across Windows and Unix systems
- Updated file operation tests to account for platform-specific behaviors:
  - Skip IO exception tests on non-Windows platforms where file locking behaves differently
  - Use platform-appropriate methods for simulating unauthorized access
  - Added proper cleanup in test teardown
- Removed unnecessary Task.CompletedTask in DeleteFileAsync
- Added platform checks using RuntimeInformation for conditional test execution

These changes ensure the file service and its tests work reliably across different operating systems while maintaining security constraints.